### PR TITLE
Tf2 compatible namespace

### DIFF
--- a/docs/core_functions/model_plugins.rst
+++ b/docs/core_functions/model_plugins.rst
@@ -297,11 +297,13 @@ added to all topic names subscribed and advertised. This is shown below.
   nh_ = ros::NodeHandle(model_->namespace_);
 
 To avid conflicts in TF frame IDs, if the plugins choose to publish TF, use
-tf::resolve() function to add prefix to **frames on the model** as shown below.
+tf::resolve() function to prepend the namespace to **frames on the model** as shown below.
 
 .. code-block:: Cpp
 
-  tf::resolve(GetModel()->GetNameSpace(), frame_id);
+  tf::resolve(GetModel()->NameSpaceTF(frame_id));
+
+NameSpaceTF will not prepend to frame_id's beginning with "/". It will instead strip the leading "/". 
 
 YAML Reader
 -----------

--- a/flatland_plugins/include/flatland_plugins/model_tf_publisher.h
+++ b/flatland_plugins/include/flatland_plugins/model_tf_publisher.h
@@ -66,9 +66,8 @@ class ModelTfPublisher : public ModelPlugin {
   std::string world_frame_id_;  ///< name of the world frame id
   bool publish_tf_world_;  ///< if to publish the world position of the bodies
   std::vector<Body *> excluded_bodies_;  ///< list of bodies to ignore
-  Body *reference_body_;   ///< body used as a reference to other bodies
-  double update_rate_;     ///< publish rate
-  std::string tf_prefix_;  ///< tf_prefix for transforms
+  Body *reference_body_;  ///< body used as a reference to other bodies
+  double update_rate_;    ///< publish rate
 
   tf::TransformBroadcaster tf_broadcaster;  ///< For publish ROS TF
   UpdateTimer update_timer_;                ///< for managing update rate

--- a/flatland_plugins/src/diff_drive.cpp
+++ b/flatland_plugins/src/diff_drive.cpp
@@ -113,7 +113,7 @@ void DiffDrive::OnInitialize(const YAML::Node& config) {
   // init the values for the messages
   ground_truth_msg_.header.frame_id = odom_frame_id;
   ground_truth_msg_.child_frame_id =
-      tf::resolve(GetModel()->GetNameSpace(), body_->name_);
+      tf::resolve("", GetModel()->NameSpaceTF(body_->name_));
   ground_truth_msg_.twist.covariance.fill(0);
   ground_truth_msg_.pose.covariance.fill(0);
   odom_msg_ = ground_truth_msg_;

--- a/flatland_plugins/src/laser.cpp
+++ b/flatland_plugins/src/laser.cpp
@@ -105,15 +105,16 @@ void Laser::OnInitialize(const YAML::Node &config) {
   laser_scan_.intensities.resize(0);
   laser_scan_.header.seq = 0;
   laser_scan_.header.frame_id =
-      tf::resolve(GetModel()->GetNameSpace(), frame_id_);
+      tf::resolve("", GetModel()->NameSpaceTF(frame_id_));
 
   // Broadcast transform between the body and laser
   tf::Quaternion q;
   q.setRPY(0, 0, origin_.theta);
 
-  laser_tf_.header.frame_id =
-      tf::resolve(GetModel()->GetNameSpace(), body_->GetName());
-  laser_tf_.child_frame_id = tf::resolve(GetModel()->GetNameSpace(), frame_id_);
+  laser_tf_.header.frame_id = tf::resolve(
+      "", GetModel()->NameSpaceTF(body_->GetName()));  // Todo: parent_tf param
+  laser_tf_.child_frame_id =
+      tf::resolve("", GetModel()->NameSpaceTF(frame_id_));
   laser_tf_.transform.translation.x = origin_.x;
   laser_tf_.transform.translation.y = origin_.y;
   laser_tf_.transform.translation.z = 0;

--- a/flatland_plugins/src/model_tf_publisher.cpp
+++ b/flatland_plugins/src/model_tf_publisher.cpp
@@ -153,8 +153,9 @@ void ModelTfPublisher::BeforePhysicsStep(const Timekeeper &timekeeper) {
 
     // publish TF
     tf_stamped.header.frame_id =
-        tf::resolve(tf_prefix_, reference_body_->name_);
-    tf_stamped.child_frame_id = tf::resolve(tf_prefix_, body->name_);
+        tf::resolve("", GetModel()->NameSpaceTF(reference_body_->name_));
+    tf_stamped.child_frame_id =
+        tf::resolve("", GetModel()->NameSpaceTF(body->name_));
     tf_stamped.transform.translation.x = rel_tf(0, 2);
     tf_stamped.transform.translation.y = rel_tf(1, 2);
     tf_stamped.transform.translation.z = 0;

--- a/flatland_plugins/src/model_tf_publisher.cpp
+++ b/flatland_plugins/src/model_tf_publisher.cpp
@@ -65,7 +65,7 @@ void ModelTfPublisher::OnInitialize(const YAML::Node &config) {
   world_frame_id_ = reader.Get<std::string>("world_frame_id", "map");
   update_rate_ = reader.Get<double>("update_rate",
                                     std::numeric_limits<double>::infinity());
-  tf_prefix_ = GetModel()->GetNameSpace();
+
   std::string ref_body_name = reader.Get<std::string>("reference", "");
   std::vector<std::string> excluded_body_names =
       reader.GetList<std::string>("exclude", {}, -1, -1);
@@ -175,7 +175,8 @@ void ModelTfPublisher::BeforePhysicsStep(const Timekeeper &timekeeper) {
     double yaw = reference_body_->physics_body_->GetAngle();
 
     tf_stamped.header.frame_id = world_frame_id_;
-    tf_stamped.child_frame_id = tf::resolve(tf_prefix_, reference_body_->name_);
+    tf_stamped.child_frame_id =
+        tf::resolve("", GetModel()->NameSpaceTF(reference_body_->name_));
     tf_stamped.transform.translation.x = p.x;
     tf_stamped.transform.translation.y = p.y;
     tf_stamped.transform.translation.z = 0;

--- a/flatland_plugins/src/tricycle_drive.cpp
+++ b/flatland_plugins/src/tricycle_drive.cpp
@@ -9,7 +9,7 @@
  * @copyright Copyright 2017 Avidbots Corp.
  * @name	tricycle_drive.cpp
  * @brief   tricycle plugin
- * @author  Mike Brousseau
+ * @author  Mike Brousseau, Chunshang Li
  *
  * Software License Agreement (BSD License)
  *

--- a/flatland_plugins/src/tricycle_drive.cpp
+++ b/flatland_plugins/src/tricycle_drive.cpp
@@ -137,7 +137,8 @@ void TricycleDrive::OnInitialize(const YAML::Node& config) {
   // init the values for the messages
   ground_truth_msg_.header.frame_id = odom_frame_id;
   ground_truth_msg_.child_frame_id =
-      tf::resolve(GetModel()->GetNameSpace(), body_->name_);
+      tf::resolve("", GetModel()->NameSpaceTF(body_->name_));
+
   ground_truth_msg_.twist.covariance.fill(0);
   ground_truth_msg_.pose.covariance.fill(0);
   odom_msg_ = ground_truth_msg_;

--- a/flatland_plugins/test/laser_test.cpp
+++ b/flatland_plugins/test/laser_test.cpp
@@ -192,18 +192,18 @@ TEST_F(LaserPluginTest, range_test) {
   }
 
   // check scan returns
-  EXPECT_TRUE(ScanEq(scan_front, "r/laser_front", -M_PI / 2, M_PI / 2, M_PI / 2,
+  EXPECT_TRUE(ScanEq(scan_front, "r_laser_front", -M_PI / 2, M_PI / 2, M_PI / 2,
                      0.0, 0.0, 0.0, 5.0, {4.5, 4.4, 4.3}, {}));
   EXPECT_TRUE(fltcmp(p1->update_rate_, std::numeric_limits<float>::infinity()))
       << "Actual: " << p1->update_rate_;
   EXPECT_EQ(p1->body_, w->models_[0]->bodies_[0]);
 
-  EXPECT_TRUE(ScanEq(scan_center, "r/center_laser", 0, 2 * M_PI, M_PI / 2, 0.0,
+  EXPECT_TRUE(ScanEq(scan_center, "r_center_laser", 0, 2 * M_PI, M_PI / 2, 0.0,
                      0.0, 0.0, 5.0, {4.8, 4.7, 4.6, 4.9, 4.8}, {}));
   EXPECT_TRUE(fltcmp(p2->update_rate_, 5000)) << "Actual: " << p2->update_rate_;
   EXPECT_EQ(p2->body_, w->models_[0]->bodies_[0]);
 
-  EXPECT_TRUE(ScanEq(scan_back, "r/laser_back", 0, 2 * M_PI, M_PI / 2, 0.0, 0.0,
+  EXPECT_TRUE(ScanEq(scan_back, "r_laser_back", 0, 2 * M_PI, M_PI / 2, 0.0, 0.0,
                      0.0, 4, {NAN, 3.2, 3.5, NAN, NAN}, {}));
   EXPECT_TRUE(fltcmp(p3->update_rate_, 1)) << "Actual: " << p2->update_rate_;
   EXPECT_EQ(p3->body_, w->models_[0]->bodies_[0]);

--- a/flatland_plugins/test/model_tf_publisher_test.cpp
+++ b/flatland_plugins/test/model_tf_publisher_test.cpp
@@ -151,33 +151,33 @@ TEST_F(ModelTfPublisherTest, tf_publish_test_A) {
 
   // check for the transformations that should exist
   tf_world_to_base =
-      tf_buffer.lookupTransform("world", "my_robot/base", ros::Time(0));
+      tf_buffer.lookupTransform("world", "my_robot_base", ros::Time(0));
   tf_world_to_antenna =
-      tf_buffer.lookupTransform("world", "my_robot/antenna", ros::Time(0));
+      tf_buffer.lookupTransform("world", "my_robot_antenna", ros::Time(0));
   tf_base_to_left_wheel = tf_buffer.lookupTransform(
-      "my_robot/base", "my_robot/left_wheel", ros::Time(0));
+      "my_robot_base", "my_robot_left_wheel", ros::Time(0));
   tf_base_to_right_wheel = tf_buffer.lookupTransform(
-      "my_robot/base", "my_robot/right_wheel", ros::Time(0));
+      "my_robot_base", "my_robot_right_wheel", ros::Time(0));
 
   // check for the transformations that should not exist
   try {
     tf_base_to_front_bumper = tf_buffer.lookupTransform(
-        "my_robot/base", "my_robot/front_bumper", ros::Time(0));
+        "my_robot_base", "my_robot_front_bumper", ros::Time(0));
     ADD_FAILURE() << "Expected an exception, but none were raised";
   } catch (const tf2::TransformException& e) {
     EXPECT_STREQ(
-        "\"my_robot/front_bumper\" passed to lookupTransform argument "
+        "\"my_robot_front_bumper\" passed to lookupTransform argument "
         "source_frame does not exist. ",
         e.what());
   }
 
   try {
     tf_base_to_rear_bumper = tf_buffer.lookupTransform(
-        "my_robot/base", "my_robot/rear_bumper", ros::Time(0));
+        "my_robot_base", "my_robot_rear_bumper", ros::Time(0));
     ADD_FAILURE() << "Expected an exception, but none were raised";
   } catch (const tf2::TransformException& e) {
     EXPECT_STREQ(
-        "\"my_robot/rear_bumper\" passed to lookupTransform argument "
+        "\"my_robot_rear_bumper\" passed to lookupTransform argument "
         "source_frame does not exist. ",
         e.what());
   }

--- a/flatland_server/CMakeLists.txt
+++ b/flatland_server/CMakeLists.txt
@@ -178,6 +178,8 @@ if(CATKIN_ENABLE_TESTING)
   target_link_libraries(load_world_test
     flatland_lib)
 
+  add_rostest_gtest(model_test test/model_test.test test/model_test.cpp)
+  target_link_libraries(model_test flatland_lib)
 
   catkin_add_gtest(geometry_test test/geometry_test.cpp)
   target_link_libraries(geometry_test

--- a/flatland_server/include/flatland_server/model.h
+++ b/flatland_server/include/flatland_server/model.h
@@ -135,6 +135,11 @@ class Model : public Entity {
   const std::string &GetNameSpace() const;
 
   /**
+   * @return prepend the tf with namespace_
+   */
+  std::string NameSpaceTF(const std::string &frame_id) const;
+
+  /**
    * @return The name of the model
    */
   const std::string &GetName() const;

--- a/flatland_server/src/layer.cpp
+++ b/flatland_server/src/layer.cpp
@@ -92,6 +92,7 @@ Layer::Layer(b2World *physics_world, CollisionFilterRegistry *cfr,
     fixture_def.shape = &edge;
     fixture_def.filter.categoryBits = category_bits;
     fixture_def.filter.maskBits = fixture_def.filter.categoryBits;
+    // todo: add material information
     body_->physics_body_->CreateFixture(&fixture_def);
   }
 }

--- a/flatland_server/src/model.cpp
+++ b/flatland_server/src/model.cpp
@@ -163,6 +163,16 @@ const std::vector<Joint *> &Model::GetJoints() { return joints_; }
 
 const std::string &Model::GetNameSpace() const { return namespace_; }
 
+std::string Model::NameSpaceTF(const std::string &frame_id) const {
+  // case: "global" namespace: don't prefix, strip leading slash
+  if (frame_id.substr(0, 1) == "/") {
+    return std::string(frame_id, 1,
+                       std::string::npos);  // Strip the leading '/'
+  } else {  // case: "local" namespace: prepend namespace
+    return std::string(namespace_) + "_" + frame_id;
+  }
+}
+
 const std::string &Model::GetName() const { return name_; }
 
 const CollisionFilterRegistry *Model::GetCfr() const { return cfr_; }

--- a/flatland_server/src/model.cpp
+++ b/flatland_server/src/model.cpp
@@ -169,7 +169,11 @@ std::string Model::NameSpaceTF(const std::string &frame_id) const {
     return std::string(frame_id, 1,
                        std::string::npos);  // Strip the leading '/'
   } else {  // case: "local" namespace: prepend namespace
-    return std::string(namespace_) + "_" + frame_id;
+    if (namespace_.length() > 0) {
+      return namespace_ + "_" + frame_id;
+    } else {
+      return frame_id;
+    }
   }
 }
 

--- a/flatland_server/test/model_test.cpp
+++ b/flatland_server/test/model_test.cpp
@@ -7,8 +7,8 @@
  *    \ \_\ \_\ \___/  \ \_\ \___,_\ \_,__/\ \____/\ \__\/\____/
  *     \/_/\/_/\/__/    \/_/\/__,_ /\/___/  \/___/  \/__/\/___/
  * @copyright Copyright 2017 Avidbots Corp.
- * @name	geometry_test.cpp
- * @brief	Test geometry
+ * @name	model_test.cpp
+ * @brief	Test model methods and functionality
  * @author Joseph Duchesne
  *
  * Software License Agreement (BSD License)
@@ -44,59 +44,32 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "flatland_server/geometry.h"
+#include "flatland_server/model.h"
 #include <gtest/gtest.h>
-#include <cmath>
+#include <ros/ros.h>
+#include <string>
+#include "flatland_server/collision_filter_registry.h"
 
-// Test the CreateTransform method
-TEST(TestSuite, testCreateTransform) {
-  flatland_server::RotateTranslate rt =
-      flatland_server::Geometry::CreateTransform(2.0, 1.0, 1.1);
+// Test the NameSpaceTF method
+TEST(TestSuite, testNameSpaceTF) {
+  flatland_server::Model has_ns(nullptr, nullptr, std::string("foo"),
+                                std::string("has_ns"));
+  // namespace "foo" onto tf "bar" => foo_bar
+  EXPECT_EQ(has_ns.NameSpaceTF("bar"), "foo_bar");
+  // namespace "foo" onto tf "/bar" => bar
+  EXPECT_EQ(has_ns.NameSpaceTF("/bar"), "bar");
 
-  EXPECT_NEAR(rt.dx, 2.0, 1e-5);
-  EXPECT_NEAR(rt.dy, 1.0, 1e-5);
-  EXPECT_NEAR(rt.cos, cosf(1.1), 1e-5);
-  EXPECT_NEAR(rt.sin, sinf(1.1), 1e-5);
-}
-
-// Test the Transform method, translation
-TEST(TestSuite, testTransformTranslate) {
-  flatland_server::RotateTranslate rt =
-      flatland_server::Geometry::CreateTransform(2.0, 1.5, 0.0);
-
-  b2Vec2 in(1.0, 2.0);
-  b2Vec2 out = flatland_server::Geometry::Transform(in, rt);
-
-  EXPECT_NEAR(out.x, 3.0, 1e-5);
-  EXPECT_NEAR(out.y, 3.5, 1e-5);
-}
-
-// Test the Transform method, rotation
-TEST(TestSuite, testTransformRotate) {
-  flatland_server::RotateTranslate rt =
-      flatland_server::Geometry::CreateTransform(0.0, 0.0, M_PI_2);
-
-  b2Vec2 in(1.0, 2.0);
-  b2Vec2 out = flatland_server::Geometry::Transform(in, rt);
-
-  EXPECT_NEAR(out.x, -2.0, 1e-5);
-  EXPECT_NEAR(out.y, 1.0, 1e-5);
-}
-
-// Test the Transform method, translation + rotation
-TEST(TestSuite, testTransformTranslateAndRotate) {
-  flatland_server::RotateTranslate rt =
-      flatland_server::Geometry::CreateTransform(1.0, 0.5, -M_PI);
-
-  b2Vec2 in(-1.0, 1.5);
-  b2Vec2 out = flatland_server::Geometry::Transform(in, rt);
-
-  EXPECT_NEAR(out.x, 2.0, 1e-5);
-  EXPECT_NEAR(out.y, -1.0, 1e-5);
+  flatland_server::Model no_ns(nullptr, nullptr, std::string(""),
+                               std::string("no_ns"));
+  // namespace "" onto tf "bar" => bar
+  EXPECT_EQ(no_ns.NameSpaceTF("bar"), "bar");
+  // namespace "" onto tf "/bar" => bar
+  EXPECT_EQ(no_ns.NameSpaceTF("/bar"), "bar");
 }
 
 // Run all the tests that were declared with TEST()
 int main(int argc, char **argv) {
+  ros::init(argc, argv, "model_test");
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/flatland_server/test/model_test.test
+++ b/flatland_server/test/model_test.test
@@ -1,0 +1,9 @@
+<!--
+Test launchfile for model_test
+
+This file is used so that rosmaster is running when the test is executed,
+in order to test publish/subscribe
+-->
+<launch>
+  <test pkg="flatland_server" type="model_test" test-name="model_test"/>
+</launch>


### PR DESCRIPTION
* Replaces TF namespace with TF2 compatible prefix. Previously a model namespaced as "foo" with tf "bar" would be tf "/foo/bar", which is incompatible with TF2. Now it's "foo_bar".