### PR TITLE
Closes #30 - Loosened tolerance on unit test EXPECT_NEAR checks

### DIFF
--- a/flatland_server/test/service_manager_test.cpp
+++ b/flatland_server/test/service_manager_test.cpp
@@ -196,9 +196,9 @@ TEST_F(ServiceManagerTest, move_model) {
 
   World* w = sim_man->world_;
   EXPECT_NEAR(5.5, w->models_[0]->bodies_[0]->physics_body_->GetPosition().x,
-              1e-4);
+              1e-2);
   EXPECT_NEAR(9.9, w->models_[0]->bodies_[0]->physics_body_->GetPosition().y,
-              1e-4);
+              1e-2);
   EXPECT_NEAR(0.77, w->models_[0]->bodies_[0]->physics_body_->GetAngle(), 1e-2);
 }
 


### PR DESCRIPTION
I ran the test a bunch of times on my computer and never saw a difference greater than the original tolerance of 1e-4, but apparently it is possible.  Loosened them to 1cm, which should still be tight enough to catch real problems that aren't just numerical computation error accumulation.