### PR TITLE
Model plugin namespaces and tf prefixes to support multiple model instances

### DIFF
--- a/flatland_plugins/include/flatland_plugins/laser.h
+++ b/flatland_plugins/include/flatland_plugins/laser.h
@@ -78,7 +78,7 @@ class Laser : public ModelPlugin, public b2RayCastCallback {
   double update_rate_;    ///< the rate laser scan will be published
   std::string frame_id_;  ///< laser frame id name
   std::string ns_;  ///< Namespace to make unique frames and topics for multiple
-                    ///instances
+                    /// instances
   bool broadcast_tf_;     ///< whether to broadcast laser origin w.r.t body
   uint16_t layers_bits_;  ///< for setting the layers where laser will function
 

--- a/flatland_plugins/include/flatland_plugins/laser.h
+++ b/flatland_plugins/include/flatland_plugins/laser.h
@@ -77,7 +77,8 @@ class Laser : public ModelPlugin, public b2RayCastCallback {
   double increment_;      ///< laser angle increment
   double update_rate_;    ///< the rate laser scan will be published
   std::string frame_id_;  ///< laser frame id name
-  std::string ns_;        ///< Namespace to make unique frames and topics for multiple instances
+  std::string ns_;  ///< Namespace to make unique frames and topics for multiple
+                    ///instances
   bool broadcast_tf_;     ///< whether to broadcast laser origin w.r.t body
   uint16_t layers_bits_;  ///< for setting the layers where laser will function
 

--- a/flatland_plugins/include/flatland_plugins/laser.h
+++ b/flatland_plugins/include/flatland_plugins/laser.h
@@ -77,6 +77,7 @@ class Laser : public ModelPlugin, public b2RayCastCallback {
   double increment_;      ///< laser angle increment
   double update_rate_;    ///< the rate laser scan will be published
   std::string frame_id_;  ///< laser frame id name
+  std::string ns_;        ///< Namespace to make unique frames and topics for multiple instances
   bool broadcast_tf_;     ///< whether to broadcast laser origin w.r.t body
   uint16_t layers_bits_;  ///< for setting the layers where laser will function
 

--- a/flatland_plugins/include/flatland_plugins/model_tf_publisher.h
+++ b/flatland_plugins/include/flatland_plugins/model_tf_publisher.h
@@ -64,6 +64,7 @@ namespace flatland_plugins {
 class ModelTfPublisher : public ModelPlugin {
  public:
   std::string world_frame_id_;  ///< name of the world frame id
+  std::string tf_prefix_;  ///< TF prefix to make unique frames for multiple instances
   bool publish_tf_world_;  ///< if to publish the world position of the bodies
   std::vector<Body *> excluded_bodies_;  ///< list of bodies to ignore
   Body *reference_body_;  ///< body used as a reference to other bodies

--- a/flatland_plugins/include/flatland_plugins/model_tf_publisher.h
+++ b/flatland_plugins/include/flatland_plugins/model_tf_publisher.h
@@ -64,7 +64,8 @@ namespace flatland_plugins {
 class ModelTfPublisher : public ModelPlugin {
  public:
   std::string world_frame_id_;  ///< name of the world frame id
-  std::string tf_prefix_;  ///< TF prefix to make unique frames for multiple instances
+  std::string
+      tf_prefix_;  ///< TF prefix to make unique frames for multiple instances
   bool publish_tf_world_;  ///< if to publish the world position of the bodies
   std::vector<Body *> excluded_bodies_;  ///< list of bodies to ignore
   Body *reference_body_;  ///< body used as a reference to other bodies

--- a/flatland_plugins/src/diff_drive.cpp
+++ b/flatland_plugins/src/diff_drive.cpp
@@ -67,17 +67,17 @@ void DiffDrive::OnInitialize(const YAML::Node& config) {
   std::string odom_frame_id = reader.Get<std::string>("odom_frame_id", "odom");
 
   std::string twist_topic = reader.Get<std::string>("twist_sub", "cmd_vel");
-  if (use_model_namespace){
+  if (use_model_namespace) {
     twist_topic = tf::resolve(ns, twist_topic);
   }
   std::string odom_topic =
       reader.Get<std::string>("odom_pub", "odometry/filtered");
-  if (use_model_namespace){
+  if (use_model_namespace) {
     odom_topic = tf::resolve(ns, odom_topic);
   }
   std::string ground_truth_topic =
       reader.Get<std::string>("ground_truth_pub", "odometry/ground_truth");
-  if (use_model_namespace){
+  if (use_model_namespace) {
     ground_truth_topic = tf::resolve(ns, ground_truth_topic);
   }
 

--- a/flatland_plugins/src/diff_drive.cpp
+++ b/flatland_plugins/src/diff_drive.cpp
@@ -62,13 +62,24 @@ void DiffDrive::TwistCallback(const geometry_msgs::Twist& msg) {
 void DiffDrive::OnInitialize(const YAML::Node& config) {
   YamlReader reader(config);
   std::string body_name = reader.Get<std::string>("body");
+  bool use_model_namespace = reader.Get<bool>("use_namespace", false);
+  std::string ns = use_model_namespace ? GetModel()->GetName() : "";
   std::string odom_frame_id = reader.Get<std::string>("odom_frame_id", "odom");
 
   std::string twist_topic = reader.Get<std::string>("twist_sub", "cmd_vel");
+  if (use_model_namespace){
+    twist_topic = tf::resolve(ns, twist_topic);
+  }
   std::string odom_topic =
       reader.Get<std::string>("odom_pub", "odometry/filtered");
+  if (use_model_namespace){
+    odom_topic = tf::resolve(ns, odom_topic);
+  }
   std::string ground_truth_topic =
       reader.Get<std::string>("ground_truth_pub", "odometry/ground_truth");
+  if (use_model_namespace){
+    ground_truth_topic = tf::resolve(ns, ground_truth_topic);
+  }
 
   // noise are in the form of linear x, linear y, angular variances
   std::vector<double> odom_twist_noise =
@@ -113,7 +124,7 @@ void DiffDrive::OnInitialize(const YAML::Node& config) {
   // init the values for the messages
   ground_truth_msg_.header.frame_id = odom_frame_id;
   ground_truth_msg_.child_frame_id =
-      tf::resolve("", GetModel()->NameSpaceTF(body_->name_));
+      tf::resolve(ns, GetModel()->NameSpaceTF(body_->name_));
   ground_truth_msg_.twist.covariance.fill(0);
   ground_truth_msg_.pose.covariance.fill(0);
   odom_msg_ = ground_truth_msg_;

--- a/flatland_plugins/src/diff_drive.cpp
+++ b/flatland_plugins/src/diff_drive.cpp
@@ -66,20 +66,12 @@ void DiffDrive::OnInitialize(const YAML::Node& config) {
   std::string ns = use_model_namespace ? GetModel()->GetName() : "";
   std::string odom_frame_id = reader.Get<std::string>("odom_frame_id", "odom");
 
-  std::string twist_topic = reader.Get<std::string>("twist_sub", "cmd_vel");
-  if (use_model_namespace) {
-    twist_topic = tf::resolve(ns, twist_topic);
-  }
+  std::string twist_topic =
+      tf::resolve(ns, reader.Get<std::string>("twist_sub", "cmd_vel"));
   std::string odom_topic =
-      reader.Get<std::string>("odom_pub", "odometry/filtered");
-  if (use_model_namespace) {
-    odom_topic = tf::resolve(ns, odom_topic);
-  }
-  std::string ground_truth_topic =
-      reader.Get<std::string>("ground_truth_pub", "odometry/ground_truth");
-  if (use_model_namespace) {
-    ground_truth_topic = tf::resolve(ns, ground_truth_topic);
-  }
+      tf::resolve(ns, reader.Get<std::string>("odom_pub", "odometry/filtered"));
+  std::string ground_truth_topic = tf::resolve(
+      ns, reader.Get<std::string>("ground_truth_pub", "odometry/ground_truth"));
 
   // noise are in the form of linear x, linear y, angular variances
   std::vector<double> odom_twist_noise =

--- a/flatland_plugins/src/laser.cpp
+++ b/flatland_plugins/src/laser.cpp
@@ -108,16 +108,16 @@ void Laser::OnInitialize(const YAML::Node &config) {
     laser_scan_.intensities.resize(0);
   laser_scan_.header.seq = 0;
   laser_scan_.header.frame_id =
-      tf::resolve("", GetModel()->NameSpaceTF(frame_id_));
+      tf::resolve(ns_, GetModel()->NameSpaceTF(frame_id_));
 
   // Broadcast transform between the body and laser
   tf::Quaternion q;
   q.setRPY(0, 0, origin_.theta);
 
   laser_tf_.header.frame_id = tf::resolve(
-      "", GetModel()->NameSpaceTF(body_->GetName()));  // Todo: parent_tf param
+      ns_, GetModel()->NameSpaceTF(body_->GetName()));  // Todo: parent_tf param
   laser_tf_.child_frame_id =
-      tf::resolve("", GetModel()->NameSpaceTF(frame_id_));
+      tf::resolve(ns_, GetModel()->NameSpaceTF(frame_id_));
   laser_tf_.transform.translation.x = origin_.x;
   laser_tf_.transform.translation.y = origin_.y;
   laser_tf_.transform.translation.z = 0;
@@ -209,7 +209,9 @@ float Laser::ReportFixture(b2Fixture *fixture, const b2Vec2 &point,
 void Laser::ParseParameters(const YAML::Node &config) {
   YamlReader reader(config);
   std::string body_name = reader.Get<std::string>("body");
-  topic_ = reader.Get<std::string>("topic", "scan");
+  bool use_model_namespace = reader.Get<bool>("use_namespace", false);
+  ns_ = use_model_namespace ? GetModel()->GetName() : "";
+  topic_ = tf::resolve(ns_, reader.Get<std::string>("topic", "scan"));
   frame_id_ = reader.Get<std::string>("frame", GetName());
   broadcast_tf_ = reader.Get<bool>("broadcast_tf", true);
   update_rate_ = reader.Get<double>("update_rate",

--- a/flatland_plugins/src/model_tf_publisher.cpp
+++ b/flatland_plugins/src/model_tf_publisher.cpp
@@ -154,8 +154,8 @@ void ModelTfPublisher::BeforePhysicsStep(const Timekeeper &timekeeper) {
     double yaw = atan2(sine, cosine);
 
     // publish TF
-    tf_stamped.header.frame_id =
-        tf::resolve(tf_prefix_, GetModel()->NameSpaceTF(reference_body_->name_));
+    tf_stamped.header.frame_id = tf::resolve(
+        tf_prefix_, GetModel()->NameSpaceTF(reference_body_->name_));
     tf_stamped.child_frame_id =
         tf::resolve(tf_prefix_, GetModel()->NameSpaceTF(body->name_));
     tf_stamped.transform.translation.x = rel_tf(0, 2);
@@ -177,8 +177,8 @@ void ModelTfPublisher::BeforePhysicsStep(const Timekeeper &timekeeper) {
     double yaw = reference_body_->physics_body_->GetAngle();
 
     tf_stamped.header.frame_id = world_frame_id_;
-    tf_stamped.child_frame_id =
-        tf::resolve(tf_prefix_, GetModel()->NameSpaceTF(reference_body_->name_));
+    tf_stamped.child_frame_id = tf::resolve(
+        tf_prefix_, GetModel()->NameSpaceTF(reference_body_->name_));
     tf_stamped.transform.translation.x = p.x;
     tf_stamped.transform.translation.y = p.y;
     tf_stamped.transform.translation.z = 0;

--- a/flatland_plugins/src/model_tf_publisher.cpp
+++ b/flatland_plugins/src/model_tf_publisher.cpp
@@ -65,6 +65,8 @@ void ModelTfPublisher::OnInitialize(const YAML::Node &config) {
   world_frame_id_ = reader.Get<std::string>("world_frame_id", "map");
   update_rate_ = reader.Get<double>("update_rate",
                                     std::numeric_limits<double>::infinity());
+  bool use_tf_prefix = reader.Get<bool>("use_tf_prefix", false);
+  tf_prefix_ = use_tf_prefix ? GetModel()->GetName() : "";
 
   std::string ref_body_name = reader.Get<std::string>("reference", "");
   std::vector<std::string> excluded_body_names =
@@ -153,9 +155,9 @@ void ModelTfPublisher::BeforePhysicsStep(const Timekeeper &timekeeper) {
 
     // publish TF
     tf_stamped.header.frame_id =
-        tf::resolve("", GetModel()->NameSpaceTF(reference_body_->name_));
+        tf::resolve(tf_prefix_, GetModel()->NameSpaceTF(reference_body_->name_));
     tf_stamped.child_frame_id =
-        tf::resolve("", GetModel()->NameSpaceTF(body->name_));
+        tf::resolve(tf_prefix_, GetModel()->NameSpaceTF(body->name_));
     tf_stamped.transform.translation.x = rel_tf(0, 2);
     tf_stamped.transform.translation.y = rel_tf(1, 2);
     tf_stamped.transform.translation.z = 0;
@@ -176,7 +178,7 @@ void ModelTfPublisher::BeforePhysicsStep(const Timekeeper &timekeeper) {
 
     tf_stamped.header.frame_id = world_frame_id_;
     tf_stamped.child_frame_id =
-        tf::resolve("", GetModel()->NameSpaceTF(reference_body_->name_));
+        tf::resolve(tf_prefix_, GetModel()->NameSpaceTF(reference_body_->name_));
     tf_stamped.transform.translation.x = p.x;
     tf_stamped.transform.translation.y = p.y;
     tf_stamped.transform.translation.z = 0;

--- a/flatland_plugins/src/tricycle_drive.cpp
+++ b/flatland_plugins/src/tricycle_drive.cpp
@@ -67,16 +67,16 @@ void TricycleDrive::OnInitialize(const YAML::Node& config) {
   string ns = use_model_namespace ? GetModel()->GetName() : "";
   string odom_frame_id = r.Get<string>("odom_frame_id", "odom");
   string twist_topic = r.Get<string>("twist_sub", "cmd_vel");
-  if (use_model_namespace){
+  if (use_model_namespace) {
     twist_topic = tf::resolve(ns, twist_topic);
   }
   string odom_topic = r.Get<string>("odom_pub", "odometry/filtered");
-  if (use_model_namespace){
+  if (use_model_namespace) {
     odom_topic = tf::resolve(ns, odom_topic);
   }
   string ground_truth_topic =
       r.Get<string>("ground_truth_pub", "odometry/ground_truth");
-  if (use_model_namespace){
+  if (use_model_namespace) {
     ground_truth_topic = tf::resolve(ns, ground_truth_topic);
   }
 

--- a/flatland_plugins/src/tricycle_drive.cpp
+++ b/flatland_plugins/src/tricycle_drive.cpp
@@ -66,19 +66,11 @@ void TricycleDrive::OnInitialize(const YAML::Node& config) {
   bool use_model_namespace = r.Get<bool>("use_namespace", false);
   string ns = use_model_namespace ? GetModel()->GetName() : "";
   string odom_frame_id = r.Get<string>("odom_frame_id", "odom");
-  string twist_topic = r.Get<string>("twist_sub", "cmd_vel");
-  if (use_model_namespace) {
-    twist_topic = tf::resolve(ns, twist_topic);
-  }
-  string odom_topic = r.Get<string>("odom_pub", "odometry/filtered");
-  if (use_model_namespace) {
-    odom_topic = tf::resolve(ns, odom_topic);
-  }
-  string ground_truth_topic =
-      r.Get<string>("ground_truth_pub", "odometry/ground_truth");
-  if (use_model_namespace) {
-    ground_truth_topic = tf::resolve(ns, ground_truth_topic);
-  }
+  string twist_topic = tf::resolve(ns, r.Get<string>("twist_sub", "cmd_vel"));
+  string odom_topic =
+      tf::resolve(ns, r.Get<string>("odom_pub", "odometry/filtered"));
+  string ground_truth_topic = tf::resolve(
+      ns, r.Get<string>("ground_truth_pub", "odometry/ground_truth"));
 
   // noise are in the form of linear x, linear y, angular variances
   vector<double> odom_twist_noise =

--- a/flatland_plugins/src/tricycle_drive.cpp
+++ b/flatland_plugins/src/tricycle_drive.cpp
@@ -63,12 +63,22 @@ void TricycleDrive::OnInitialize(const YAML::Node& config) {
   string front_wj_name = r.Get<string>("front_wheel_joint");
   string rear_left_wj_name = r.Get<string>("rear_left_wheel_joint");
   string rear_right_wj_name = r.Get<string>("rear_right_wheel_joint");
+  bool use_model_namespace = r.Get<bool>("use_namespace", false);
+  string ns = use_model_namespace ? GetModel()->GetName() : "";
   string odom_frame_id = r.Get<string>("odom_frame_id", "odom");
-
   string twist_topic = r.Get<string>("twist_sub", "cmd_vel");
+  if (use_model_namespace){
+    twist_topic = tf::resolve(ns, twist_topic);
+  }
   string odom_topic = r.Get<string>("odom_pub", "odometry/filtered");
+  if (use_model_namespace){
+    odom_topic = tf::resolve(ns, odom_topic);
+  }
   string ground_truth_topic =
       r.Get<string>("ground_truth_pub", "odometry/ground_truth");
+  if (use_model_namespace){
+    ground_truth_topic = tf::resolve(ns, ground_truth_topic);
+  }
 
   // noise are in the form of linear x, linear y, angular variances
   vector<double> odom_twist_noise =
@@ -142,7 +152,7 @@ void TricycleDrive::OnInitialize(const YAML::Node& config) {
   // init the values for the messages
   ground_truth_msg_.header.frame_id = odom_frame_id;
   ground_truth_msg_.child_frame_id =
-      tf::resolve("", GetModel()->NameSpaceTF(body_->name_));
+      tf::resolve(ns, GetModel()->NameSpaceTF(body_->name_));
 
   ground_truth_msg_.twist.covariance.fill(0);
   ground_truth_msg_.pose.covariance.fill(0);


### PR DESCRIPTION
I am setting up some multi-robot simulations and was having issues with the different instances of the Laser, ModelTfPublisher, and DiffDrive plugin colliding on topics and TF transform broadcasters.

I made some changes to these plugins to support prefixing topic names and frame IDs with the model name so that multiple instances play nicely with each other.  I made equivalent changes to TricycleDrive as I did to DiffDrive so you can test it out with the 'cleaner' model.  To test it myself, I just made a second copy of the cleaner model in the default world file so there were two models: cleaner1 and cleaner2.

In the Laser, DiffDrive, and TricycleDrive plugins, I added a boolean YAML parameter 'use_namespace'.  If false, then they behave the same as before.  If true, the model name is prefixed on the necessary topic names and frame IDs.

In the ModelTfPublisher plugin, I added a boolean YAML parameter 'use_tf_prefix', which behaves in a similar fashion to 'use_namespace' in the other plugins.

These two new parameters default to false, so everything will behave as normal by default.