### PR TITLE
Lua preprocessor for yaml

### DIFF
--- a/docs/core_functions/models.rst
+++ b/docs/core_functions/models.rst
@@ -17,6 +17,9 @@ shown here. Examples can be found in flatland_server/tests.
       # required, name of the body, must be unique within the model
     - name: base_link
 
+      # optional, default true. If false (see yaml preprocessor for details), this body is skipped
+      enabled: true
+
       # optional, defaults to [0, 0, 0], in the form of [x, y, theta] w.r.t the
       # model pose specified in world yaml. Pose is simply the initial pose
       # of the body, it does not add additional constrains in any way
@@ -115,6 +118,9 @@ shown here. Examples can be found in flatland_server/tests.
       # joint types
       name: rear_wheel_revolute
 
+      # optional, default true. If false (see yaml preprocessor for details), this joint is skipped
+      enabled: true
+
       # optional, default to false, specifies whether two bodies connected a
       # this joint should collide with each other, applies to all joint types
       collide_connected: false
@@ -185,6 +191,9 @@ shown here. Examples can be found in flatland_server/tests.
       # required, type of the plugin to load. Note the plugin must be configured
       # property to be discovered. See the Writing Model Plugins page
     - type: Laser
+
+      # optional, default true. If false (see yaml preprocessor for details), this plugin is skipped
+      enabled: true
 
       # required, name of the plugin to load, must be unique in a model
       name: kinect

--- a/docs/core_functions/yaml_preprocessor.rst
+++ b/docs/core_functions/yaml_preprocessor.rst
@@ -1,0 +1,73 @@
+.. image:: ../_static/flatland_logo2.png
+    :width: 250px
+    :align: right
+    :target: ../_static/flatland_logo2.png
+
+Yaml Preprocessor
+==============================
+
+Flatland Server has a lua preprocessor for YAML with simple bindings for the environment variables and rosparam.
+The intent is to be able to build parametric models that are defined by dimensions and flags found in either environment variables or rosparam, in a similar way to xacro+urdf. Because this is parsed at model load time, any roslaunch rosparam loading will have completed and those parameters will be available.
+
+body/joint/plugin enabled flag
+------------------------------
+Model bodies, plugins and joints now have a new flag `enabled` which can be set to true or false either directly in the yaml, or based on more complex logic from a lua `$eval` string that returns "true" or "false". Disabled bodies, plugins and joints are skipped during yaml loading, and as a result are never instantiated. From Flatland's perspective `enabled: false` causes the affected body/plugin/joint to be deleted. 
+
+bindings for env and param
+-------------------------------
+
+Additional lua function bindings (beyond the normal standard libraries such as string, math, etc.):
+.. code-block:: lua
+  env(EnvName)  -- blank string + warning if not found
+  env(EnvName, Default)
+  param(ParamPath)  -- blank string + warning if not found
+  param(ParamPath, Default)
+
+Sample expressions
+------------------------------
+
+.. code-block:: yaml
+  foo: $eval "Some arbitrary LUA expression"
+  bar: |  # Multiline string
+    $eval  -- $eval flag required to trigger LUA parsing
+    if env("FRONT_WHEEL",true) then
+      return 1.2
+    else
+      return 2.4
+    end
+
+Lua expressions can explicitly `return` their value, but if no `return` is given, one will be prepended to the statement.
+
+env + param examples
+-----------------------------
+
+.. code-block:: yaml
+  # in: (SOME_ENV not set)
+  foo: $eval env("SOME_ENV")
+  # out:
+  foo: ""
+
+.. code-block:: yaml
+  # in: (SOME_ENV not set)
+  foo: $eval env("SOME_ENV", false)
+  # out:
+  foo: false
+
+.. code-block:: yaml
+  # in: (export SOME_ENV=true)
+  foo: $eval env("SOME_ENV")
+  # out:
+  foo: true
+
+.. code-block:: yaml
+  # in: (rosparam /test/param not set)
+  foo: $eval param("/test/param", 0)/2.0
+  # out:
+  foo: 0
+
+.. code-block:: yaml
+  # in: (rosparam /test/param set to 5.0)
+  foo: $eval param("/test/param", 0)/2.0 + 1
+  # out:
+  foo: 2.5
+

--- a/docs/core_functions/yaml_preprocessor.rst
+++ b/docs/core_functions/yaml_preprocessor.rst
@@ -18,7 +18,8 @@ bindings for env and param
 
 Additional lua function bindings (beyond the normal standard libraries such as string, math, etc.):
 
-.. highlight:: lua
+.. code-block:: lua
+
   env(EnvName)  -- blank string + warning if not found
   env(EnvName, Default)
   param(ParamPath)  -- blank string + warning if not found
@@ -27,7 +28,8 @@ Additional lua function bindings (beyond the normal standard libraries such as s
 Sample expressions
 ------------------------------
 
-.. highlight:: yaml
+.. code-block:: yaml
+
   foo: $eval "Some arbitrary LUA expression"
   bar: |  # Multiline string
     $eval  -- $eval flag required to trigger LUA parsing
@@ -42,31 +44,36 @@ Lua expressions can explicitly `return` their value, but if no `return` is given
 env + param examples
 -----------------------------
 
-.. highlight:: yaml
+.. code-block:: yaml
+
   # in: (SOME_ENV not set)
   foo: $eval env("SOME_ENV")
   # out:
   foo: ""
 
-.. highlight:: yaml
+.. code-block:: yaml
+
   # in: (SOME_ENV not set)
   foo: $eval env("SOME_ENV", false)
   # out:
   foo: false
 
-.. highlight:: yaml
+.. code-block:: yaml
+
   # in: (export SOME_ENV=true)
   foo: $eval env("SOME_ENV")
   # out:
   foo: true
 
-.. highlight:: yaml
+.. code-block:: yaml
+
   # in: (rosparam /test/param not set)
   foo: $eval param("/test/param", 0)/2.0
   # out:
   foo: 0
 
-.. highlight:: yaml
+.. code-block:: yaml
+
   # in: (rosparam /test/param set to 5.0)
   foo: $eval param("/test/param", 0)/2.0 + 1
   # out:

--- a/docs/core_functions/yaml_preprocessor.rst
+++ b/docs/core_functions/yaml_preprocessor.rst
@@ -17,7 +17,8 @@ bindings for env and param
 -------------------------------
 
 Additional lua function bindings (beyond the normal standard libraries such as string, math, etc.):
-.. code-block:: lua
+
+.. highlight:: lua
   env(EnvName)  -- blank string + warning if not found
   env(EnvName, Default)
   param(ParamPath)  -- blank string + warning if not found
@@ -26,7 +27,7 @@ Additional lua function bindings (beyond the normal standard libraries such as s
 Sample expressions
 ------------------------------
 
-.. code-block:: yaml
+.. highlight:: yaml
   foo: $eval "Some arbitrary LUA expression"
   bar: |  # Multiline string
     $eval  -- $eval flag required to trigger LUA parsing
@@ -41,31 +42,31 @@ Lua expressions can explicitly `return` their value, but if no `return` is given
 env + param examples
 -----------------------------
 
-.. code-block:: yaml
+.. highlight:: yaml
   # in: (SOME_ENV not set)
   foo: $eval env("SOME_ENV")
   # out:
   foo: ""
 
-.. code-block:: yaml
+.. highlight:: yaml
   # in: (SOME_ENV not set)
   foo: $eval env("SOME_ENV", false)
   # out:
   foo: false
 
-.. code-block:: yaml
+.. highlight:: yaml
   # in: (export SOME_ENV=true)
   foo: $eval env("SOME_ENV")
   # out:
   foo: true
 
-.. code-block:: yaml
+.. highlight:: yaml
   # in: (rosparam /test/param not set)
   foo: $eval param("/test/param", 0)/2.0
   # out:
   foo: 0
 
-.. code-block:: yaml
+.. highlight:: yaml
   # in: (rosparam /test/param set to 5.0)
   foo: $eval param("/test/param", 0)/2.0 + 1
   # out:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,6 +36,7 @@ Class APIs are documented `here <http://flatland-simulator-api.readthedocs.io/>`
    core_functions/world
    core_functions/layers
    core_functions/models
+   core_functions/yaml_preprocessor
    core_functions/ros_services
    core_functions/model_plugins
    core_functions/joystick

--- a/flatland_server/CMakeLists.txt
+++ b/flatland_server/CMakeLists.txt
@@ -33,6 +33,9 @@ find_library(YAML_CPP_LIBRARY
              PATHS ${YAML_CPP_LIBRARY_DIRS})
 link_directories(${YAML_CPP_LIBRARY_DIRS})
 
+# lua5.1
+find_package(Lua 5.1 QUIET)
+
 # OpenCV
 find_package(OpenCV REQUIRED)
 
@@ -71,6 +74,7 @@ include_directories(
   ${YAML_CPP_INCLUDE_DIRS}
   ${OpenCV_INCLUDE_DIRS}
   ${Boost_INCLUDE_DIRS}
+  ${LUA_INCLUDE_DIR}
   thirdparty
 )
 
@@ -98,6 +102,7 @@ add_library(flatland_lib
   src/yaml_reader.cpp
   src/dummy_model_plugin.cpp 
   src/dummy_world_plugin.cpp
+  src/yaml_preprocessor.cpp
 )
 
 add_dependencies(flatland_lib ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
@@ -105,6 +110,7 @@ target_link_libraries(flatland_lib
   ${catkin_LIBRARIES}
   ${OpenCV_LIBRARIES}
   ${Boost_LIBRARIES}
+  ${LUA_LIBRARIES}
   flatland_Box2D
   yaml-cpp
 )
@@ -123,6 +129,7 @@ target_link_libraries(flatland_server
   ${catkin_LIBRARIES}
   ${OpenCV_LIBRARIES}
   ${Boost_LIBRARIES}
+  ${LUA_LIBRARIES}
   flatland_Box2D
   yaml-cpp
   flatland_lib
@@ -225,6 +232,12 @@ if(CATKIN_ENABLE_TESTING)
                     test/dummy_world_plugin_test.cpp) 
   target_link_libraries(dummy_world_plugin_test
                         flatland_lib yaml-cpp) 
+
+  add_rostest_gtest(yaml_preprocessor_test
+                    test/yaml_preprocessor/yaml_preprocessor_test.test 
+                    test/yaml_preprocessor/yaml_preprocessor_test.cpp) 
+  target_link_libraries(yaml_preprocessor_test
+                        flatland_lib yaml-cpp)
 
 
 endif()

--- a/flatland_server/include/flatland_server/yaml_preprocessor.h
+++ b/flatland_server/include/flatland_server/yaml_preprocessor.h
@@ -61,46 +61,45 @@ namespace flatland_server {
 
 /**
  */
-class YamlPreprocessor {
- public:
-  /**
-   * @brief Preprocess with a given node
-   * @param[in/out] node A Yaml node to parse
-   * @return The parsed YAML::Node
-   */
-  static void Parse(YAML::Node &node);
+namespace YamlPreprocessor {
+/**
+ * @brief Preprocess with a given node
+ * @param[in/out] node A Yaml node to parse
+ * @return The parsed YAML::Node
+ */
+void Parse(YAML::Node &node);
 
-  /**
-   * @brief Constructor with a given path to a yaml file, throws exception on
-   * failure
-   * @param[in] path Path to the yaml file
-   * @return The parsed YAML::Node
-   */
-  static YAML::Node LoadParse(const std::string &path);
+/**
+ * @brief Constructor with a given path to a yaml file, throws exception on
+ * failure
+ * @param[in] path Path to the yaml file
+ * @return The parsed YAML::Node
+ */
+YAML::Node LoadParse(const std::string &path);
 
-  /**
-   * @brief Find and run any eval nodes ($evalString etc.)
-   * @param[in/out] node A Yaml node to recursively parse
-   */
-  static void ProcessNodes(YAML::Node &node);
+/**
+ * @brief Find and run any eval nodes ($evalString etc.)
+ * @param[in/out] node A Yaml node to recursively parse
+ */
+void ProcessNodes(YAML::Node &node);
 
-  /**
-   * @brief Find and run any eval expressions ($evalString etc.)
-   * @param[in/out] node A Yaml string node to parse
-   */
-  static void ProcessScalarNode(YAML::Node &node);
+/**
+ * @brief Find and run any eval expressions ($evalString etc.)
+ * @param[in/out] node A Yaml string node to parse
+ */
+void ProcessScalarNode(YAML::Node &node);
 
-  /**
-    * @brief Get an environment variable with an optional default value
-    * @param[in/out] lua_State The lua state/stack to read/write to/from
-    */
-  static int LuaGetEnv(lua_State *L);
+/**
+  * @brief Get an environment variable with an optional default value
+  * @param[in/out] lua_State The lua state/stack to read/write to/from
+  */
+int LuaGetEnv(lua_State *L);
 
-  /**
-    * @brief Get a rosparam with an optional default value
-    * @param[in/out] lua_State The lua state/stack to read/write to/from
-    */
-  static int LuaGetParam(lua_State *L);
+/**
+  * @brief Get a rosparam with an optional default value
+  * @param[in/out] lua_State The lua state/stack to read/write to/from
+  */
+int LuaGetParam(lua_State *L);
 };
 }
 

--- a/flatland_server/include/flatland_server/yaml_preprocessor.h
+++ b/flatland_server/include/flatland_server/yaml_preprocessor.h
@@ -50,12 +50,12 @@
 #include <flatland_server/exceptions.h>
 #include <yaml-cpp/yaml.h>
 
+#include <lauxlib.h>
+#include <lua.h>
+#include <lualib.h>
 #include <set>
 #include <string>
 #include <vector>
-#include <lua.h>
-#include <lauxlib.h>
-#include <lualib.h>
 
 namespace flatland_server {
 
@@ -90,19 +90,18 @@ class YamlPreprocessor {
    */
   static void ProcessScalarNode(YAML::Node &node);
 
- /**
-   * @brief Get an environment variable with an optional default value
-   * @param[in/out] lua_State The lua state/stack to read/write to/from
-   */
+  /**
+    * @brief Get an environment variable with an optional default value
+    * @param[in/out] lua_State The lua state/stack to read/write to/from
+    */
   static int LuaGetEnv(lua_State *L);
 
- /**
-   * @brief Get a rosparam with an optional default value
-   * @param[in/out] lua_State The lua state/stack to read/write to/from
-   */
+  /**
+    * @brief Get a rosparam with an optional default value
+    * @param[in/out] lua_State The lua state/stack to read/write to/from
+    */
   static int LuaGetParam(lua_State *L);
 };
-
 }
 
 #endif  // FLATLAND_SERVER_YAML_PREPROCESSOR_H

--- a/flatland_server/include/flatland_server/yaml_preprocessor.h
+++ b/flatland_server/include/flatland_server/yaml_preprocessor.h
@@ -1,0 +1,108 @@
+/*
+ *  ______                   __  __              __
+ * /\  _  \           __    /\ \/\ \            /\ \__
+ * \ \ \L\ \  __  __ /\_\   \_\ \ \ \____    ___\ \ ,_\   ____
+ *  \ \  __ \/\ \/\ \\/\ \  /'_` \ \ '__`\  / __`\ \ \/  /',__\
+ *   \ \ \/\ \ \ \_/ |\ \ \/\ \L\ \ \ \L\ \/\ \L\ \ \ \_/\__, `\
+ *    \ \_\ \_\ \___/  \ \_\ \___,_\ \_,__/\ \____/\ \__\/\____/
+ *     \/_/\/_/\/__/    \/_/\/__,_ /\/___/  \/___/  \/__/\/___/
+ * @copyright Copyright 2018 Avidbots Corp.
+ * @name	 yaml_preprocessor.h
+ * @brief	 Yaml preprocessor using Lua
+ * @author Joseph Duchesne
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, Avidbots Corp.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Avidbots Corp. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef FLATLAND_SERVER_YAML_PREPROCESSOR_H
+#define FLATLAND_SERVER_YAML_PREPROCESSOR_H
+
+#include <flatland_server/exceptions.h>
+#include <yaml-cpp/yaml.h>
+
+#include <set>
+#include <string>
+#include <vector>
+#include <lua.h>
+#include <lauxlib.h>
+#include <lualib.h>
+
+namespace flatland_server {
+
+/**
+ */
+class YamlPreprocessor {
+ public:
+  /**
+   * @brief Preprocess with a given node
+   * @param[in/out] node A Yaml node to parse
+   * @return The parsed YAML::Node
+   */
+  static void Parse(YAML::Node &node);
+
+  /**
+   * @brief Constructor with a given path to a yaml file, throws exception on
+   * failure
+   * @param[in] path Path to the yaml file
+   * @return The parsed YAML::Node
+   */
+  static YAML::Node LoadParse(const std::string &path);
+
+  /**
+   * @brief Find and run any eval nodes ($evalString etc.)
+   * @param[in/out] node A Yaml node to recursively parse
+   */
+  static void ProcessNodes(YAML::Node &node);
+
+  /**
+   * @brief Find and run any eval expressions ($evalString etc.)
+   * @param[in/out] node A Yaml string node to parse
+   */
+  static void ProcessScalarNode(YAML::Node &node);
+
+ /**
+   * @brief Get an environment variable with an optional default value
+   * @param[in/out] lua_State The lua state/stack to read/write to/from
+   */
+  static int LuaGetEnv(lua_State *L);
+
+ /**
+   * @brief Get a rosparam with an optional default value
+   * @param[in/out] lua_State The lua state/stack to read/write to/from
+   */
+  static int LuaGetParam(lua_State *L);
+};
+
+}
+
+#endif  // FLATLAND_SERVER_YAML_PREPROCESSOR_H

--- a/flatland_server/package.xml
+++ b/flatland_server/package.xml
@@ -26,6 +26,7 @@
   <depend>visualization_msgs</depend>
   <depend>interactive_markers</depend>
   <depend>flatland_msgs</depend>
+  <depend>lua-dev</depend>
 
   <export>
     <flatland_server plugin="${prefix}/flatland_plugins.xml" />

--- a/flatland_server/src/layer.cpp
+++ b/flatland_server/src/layer.cpp
@@ -301,7 +301,11 @@ void Layer::LoadFromBitmap(const cv::Mat &bitmap, double occupied_thresh,
 }
 
 void Layer::DebugVisualize() const {
-  ROS_WARN("======== 3d visualize? ===========");
+  // Don't try to visualized uninitalized layers
+  if (viz_name_.length() == 0) {
+    return;
+  }
+
   DebugVisualization::Get().Reset(viz_name_);
   DebugVisualization::Get().Reset(viz_name_ + "_3d");
 

--- a/flatland_server/src/model.cpp
+++ b/flatland_server/src/model.cpp
@@ -107,16 +107,11 @@ void Model::LoadBodies(YamlReader &bodies_reader) {
     for (int i = 0; i < bodies_reader.NodeSize(); i++) {
       YamlReader body_reader = bodies_reader.Subnode(i, YamlReader::MAP);
       if (!body_reader.Get<bool>("enabled", "true")) {
-        ROS_WARN_STREAM("Body "
+        ROS_INFO_STREAM("Body "
                         << Q(name_) << "."
                         << body_reader.Get<std::string>("name", "unnamed")
                         << " disabled");
         continue;
-      } else {
-        ROS_WARN_STREAM("Body "
-                        << Q(name_) << "."
-                        << body_reader.Get<std::string>("name", "unnamed")
-                        << " enabled");
       }
       ModelBody *b =
           ModelBody::MakeBody(physics_world_, cfr_, this, body_reader);
@@ -138,16 +133,11 @@ void Model::LoadJoints(YamlReader &joints_reader) {
     for (int i = 0; i < joints_reader.NodeSize(); i++) {
       YamlReader joint_reader = joints_reader.Subnode(i, YamlReader::MAP);
       if (!joint_reader.Get<bool>("enabled", "true")) {
-        ROS_WARN_STREAM("Joint "
+        ROS_INFO_STREAM("Joint "
                         << Q(name_) << "."
                         << joint_reader.Get<std::string>("name", "unnamed")
                         << " disabled");
         continue;
-      } else {
-        ROS_WARN_STREAM("Joint "
-                        << Q(name_) << "."
-                        << joint_reader.Get<std::string>("name", "unnamed")
-                        << " enabled");
       }
       Joint *j = Joint::MakeJoint(physics_world_, this, joint_reader);
       joints_.push_back(j);

--- a/flatland_server/src/model.cpp
+++ b/flatland_server/src/model.cpp
@@ -106,6 +106,18 @@ void Model::LoadBodies(YamlReader &bodies_reader) {
   } else {
     for (int i = 0; i < bodies_reader.NodeSize(); i++) {
       YamlReader body_reader = bodies_reader.Subnode(i, YamlReader::MAP);
+      if (!body_reader.Get<bool>("enabled", "true")) {
+        ROS_WARN_STREAM("Body "
+                        << Q(name_) << "."
+                        << body_reader.Get<std::string>("name", "unnamed")
+                        << " disabled");
+        continue;
+      } else {
+        ROS_WARN_STREAM("Body "
+                        << Q(name_) << "."
+                        << body_reader.Get<std::string>("name", "unnamed")
+                        << " enabled");
+      }
       ModelBody *b =
           ModelBody::MakeBody(physics_world_, cfr_, this, body_reader);
       bodies_.push_back(b);
@@ -125,6 +137,18 @@ void Model::LoadJoints(YamlReader &joints_reader) {
   if (!joints_reader.IsNodeNull()) {
     for (int i = 0; i < joints_reader.NodeSize(); i++) {
       YamlReader joint_reader = joints_reader.Subnode(i, YamlReader::MAP);
+      if (!joint_reader.Get<bool>("enabled", "true")) {
+        ROS_WARN_STREAM("Joint "
+                        << Q(name_) << "."
+                        << joint_reader.Get<std::string>("name", "unnamed")
+                        << " disabled");
+        continue;
+      } else {
+        ROS_WARN_STREAM("Joint "
+                        << Q(name_) << "."
+                        << joint_reader.Get<std::string>("name", "unnamed")
+                        << " enabled");
+      }
       Joint *j = Joint::MakeJoint(physics_world_, this, joint_reader);
       joints_.push_back(j);
 

--- a/flatland_server/src/plugin_manager.cpp
+++ b/flatland_server/src/plugin_manager.cpp
@@ -116,6 +116,18 @@ void PluginManager::LoadModelPlugin(Model *model, YamlReader &plugin_reader) {
                         " already exists");
   }
 
+  if (!plugin_reader.Get<bool>("enabled", "true")) {
+    ROS_WARN_STREAM("Plugin "
+                    << Q(model->name_) << "."
+                    << plugin_reader.Get<std::string>("name", "unnamed")
+                    << " disabled");
+    return;
+  } else {
+    ROS_WARN_STREAM("Body " << Q(model->name_) << "."
+                            << plugin_reader.Get<std::string>("name", "unnamed")
+                            << " enabled");
+  }
+
   // remove the name and type of the YAML Node, the plugin does not need to know
   // about these parameters, remove method is broken in yaml cpp 5.2, so we
   // create a new node and add everything

--- a/flatland_server/src/plugin_manager.cpp
+++ b/flatland_server/src/plugin_manager.cpp
@@ -123,11 +123,6 @@ void PluginManager::LoadModelPlugin(Model *model, YamlReader &plugin_reader) {
                       << plugin_reader.Get<std::string>("name", "unnamed")
                       << " disabled");
       return;
-    } else {
-      ROS_WARN_STREAM("Body "
-                      << Q(model->name_) << "."
-                      << plugin_reader.Get<std::string>("name", "unnamed")
-                      << " enabled");
     }
   } catch (...) {
     ROS_WARN_STREAM("Body " << Q(model->name_) << "."

--- a/flatland_server/src/plugin_manager.cpp
+++ b/flatland_server/src/plugin_manager.cpp
@@ -116,16 +116,24 @@ void PluginManager::LoadModelPlugin(Model *model, YamlReader &plugin_reader) {
                         " already exists");
   }
 
-  if (!plugin_reader.Get<bool>("enabled", "true")) {
-    ROS_WARN_STREAM("Plugin "
-                    << Q(model->name_) << "."
-                    << plugin_reader.Get<std::string>("name", "unnamed")
-                    << " disabled");
-    return;
-  } else {
+  try {
+    if (!plugin_reader.Get<bool>("enabled", "true")) {
+      ROS_WARN_STREAM("Plugin "
+                      << Q(model->name_) << "."
+                      << plugin_reader.Get<std::string>("name", "unnamed")
+                      << " disabled");
+      return;
+    } else {
+      ROS_WARN_STREAM("Body "
+                      << Q(model->name_) << "."
+                      << plugin_reader.Get<std::string>("name", "unnamed")
+                      << " enabled");
+    }
+  } catch (...) {
     ROS_WARN_STREAM("Body " << Q(model->name_) << "."
                             << plugin_reader.Get<std::string>("name", "unnamed")
-                            << " enabled");
+                            << " enabled because flag failed to parse: "
+                            << plugin_reader.Get<std::string>("enabled"));
   }
 
   // remove the name and type of the YAML Node, the plugin does not need to know

--- a/flatland_server/src/yaml_preprocessor.cpp
+++ b/flatland_server/src/yaml_preprocessor.cpp
@@ -81,6 +81,7 @@ void YamlPreprocessor::ProcessNodes(YAML::Node &node) {
 void YamlPreprocessor::ProcessScalarNode(YAML::Node &node) {
   std::string value = node.as<std::string>().substr(5);  // omit the $parse
   boost::algorithm::trim(value);                         // trim whitespace
+  ROS_INFO_STREAM("Attempting to parse lua " << value);
 
   try {
     if (value.find("return ") ==
@@ -110,10 +111,12 @@ void YamlPreprocessor::ProcessScalarNode(YAML::Node &node) {
                         << value << " as bool "
                         << (lua_toboolean(L, 1) ? "true" : "false"));
         node = lua_toboolean(L, 1) ? "true" : "false";
-      } else {
+      } else if (t == LUA_TSTRING || t == LUA_TNUMBER) {
         ROS_INFO_STREAM("Preprocessor parsed " << value << " as "
                                                << lua_tostring(L, 1));
         node = lua_tostring(L, 1);
+      } else {
+        ROS_ERROR_STREAM("No lua output for " << value);
       }
     }
   } catch (...) {

--- a/flatland_server/src/yaml_preprocessor.cpp
+++ b/flatland_server/src/yaml_preprocessor.cpp
@@ -49,13 +49,13 @@
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/lexical_cast.hpp>
 
-#include <cstring>
 #include <cstdlib>
- 
+#include <cstring>
+
 namespace flatland_server {
 
 void YamlPreprocessor::Parse(YAML::Node &node) {
-  ROS_WARN_NAMED("YamlPreprocessor","Parse called!");
+  ROS_WARN_NAMED("YamlPreprocessor", "Parse called!");
 
   YamlPreprocessor::ProcessNodes(node);
 }
@@ -63,12 +63,12 @@ void YamlPreprocessor::Parse(YAML::Node &node) {
 void YamlPreprocessor::ProcessNodes(YAML::Node &node) {
   switch (node.Type()) {
     case YAML::NodeType::Sequence:
-      for (YAML::Node child : node){
+      for (YAML::Node child : node) {
         YamlPreprocessor::ProcessNodes(child);
       }
       break;
     case YAML::NodeType::Map:
-      for(YAML::iterator it=node.begin();it!=node.end();++it) {
+      for (YAML::iterator it = node.begin(); it != node.end(); ++it) {
         YamlPreprocessor::ProcessNodes(it->second);
       }
       break;
@@ -83,10 +83,9 @@ void YamlPreprocessor::ProcessNodes(YAML::Node &node) {
 }
 
 void YamlPreprocessor::ProcessScalarNode(YAML::Node &node) {
-  std::string value = node.as<std::string>().substr(5);  //omit the $parse
-  boost::algorithm::trim(value); //trim whitespace
+  std::string value = node.as<std::string>().substr(5);  // omit the $parse
+  boost::algorithm::trim(value);                         // trim whitespace
 
-  
   if (value.find("return ") == std::string::npos) {  // Has no return statement
     value = "return " + value;
   }
@@ -104,15 +103,14 @@ void YamlPreprocessor::ProcessScalarNode(YAML::Node &node) {
   int error = luaL_dostring(L, value.c_str());
   if (error) {
     ROS_ERROR_STREAM(lua_tostring(L, -1));
-    lua_pop(L, 1);  /* pop error message from the stack */
+    lua_pop(L, 1); /* pop error message from the stack */
   } else {
     int t = lua_type(L, 1);
-    if ( t == LUA_TNIL ) {
+    if (t == LUA_TNIL) {
       ROS_ERROR_STREAM("NULL result");
     } else {
       ROS_ERROR_STREAM("result: " << lua_tostring(L, 1));
     }
-    
   }
 }
 
@@ -135,7 +133,7 @@ YAML::Node YamlPreprocessor::LoadParse(const std::string &path) {
 
 int YamlPreprocessor::LuaGetEnv(lua_State *L) {
   const char *name = lua_tostring(L, 1);
-  const char* env = std::getenv(name);
+  const char *env = std::getenv(name);
 
   if (lua_gettop(L) == 2) {  // default passed in
     if (lua_isnumber(L, 2)) {
@@ -151,18 +149,18 @@ int YamlPreprocessor::LuaGetEnv(lua_State *L) {
         lua_pushstring(L, env);
       }
     }
-  } else {  // no default
+  } else {              // no default
     if (env == NULL) {  // Push back a nil
       ROS_ERROR_STREAM("No environment variable for: " << name);
-      lua_pushnil(L); 
+      lua_pushnil(L);
     } else {
       try {  // Try to push a number
         double x = boost::lexical_cast<double>(env);
         ROS_ERROR_STREAM("Assuming number for: " << name);
         lua_pushnumber(L, x);
-      } catch(boost::bad_lexical_cast&) {  // Otherwise it's a string
+      } catch (boost::bad_lexical_cast &) {  // Otherwise it's a string
         ROS_ERROR_STREAM("Assuming string for: " << name);
-        lua_pushstring(L,env);
+        lua_pushstring(L, env);
       }
     }
   }
@@ -189,16 +187,16 @@ int YamlPreprocessor::LuaGetParam(lua_State *L) {
         lua_pushstring(L, param.c_str());
       }
     }
-  } else {  // no default
+  } else {                         // no default
     if (!ros::param::has(name)) {  // Push back a nil
       ROS_ERROR_STREAM("No environment variable for: " << name);
-      lua_pushnil(L); 
+      lua_pushnil(L);
     } else {
       try {  // Try to push a number
         double x = boost::lexical_cast<double>(param.c_str());
         ROS_ERROR_STREAM("Assuming number for: " << name);
         lua_pushnumber(L, x);
-      } catch(boost::bad_lexical_cast&) {  // Otherwise it's a string
+      } catch (boost::bad_lexical_cast &) {  // Otherwise it's a string
         ROS_ERROR_STREAM("Assuming string for: " << name);
         lua_pushstring(L, param.c_str());
       }
@@ -207,5 +205,4 @@ int YamlPreprocessor::LuaGetParam(lua_State *L) {
 
   return 1;  // 1 return value
 }
-
 }

--- a/flatland_server/src/yaml_preprocessor.cpp
+++ b/flatland_server/src/yaml_preprocessor.cpp
@@ -1,0 +1,211 @@
+/*
+ *  ______                   __  __              __
+ * /\  _  \           __    /\ \/\ \            /\ \__
+ * \ \ \L\ \  __  __ /\_\   \_\ \ \ \____    ___\ \ ,_\   ____
+ *  \ \  __ \/\ \/\ \\/\ \  /'_` \ \ '__`\  / __`\ \ \/  /',__\
+ *   \ \ \/\ \ \ \_/ |\ \ \/\ \L\ \ \ \L\ \/\ \L\ \ \ \_/\__, `\
+ *    \ \_\ \_\ \___/  \ \_\ \___,_\ \_,__/\ \____/\ \__\/\____/
+ *     \/_/\/_/\/__/    \/_/\/__,_ /\/___/  \/___/  \/__/\/___/
+ * @copyright Copyright 2018 Avidbots Corp.
+ * @name	 yaml_preprocessor
+ * @brief	 Yaml preprocessor using Lua
+ * @author Joseph Duchesne
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, Avidbots Corp.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Avidbots Corp. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "flatland_server/yaml_preprocessor.h"
+#include <ros/ros.h>
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/lexical_cast.hpp>
+
+#include <cstring>
+#include <cstdlib>
+ 
+namespace flatland_server {
+
+void YamlPreprocessor::Parse(YAML::Node &node) {
+  ROS_WARN_NAMED("YamlPreprocessor","Parse called!");
+
+  YamlPreprocessor::ProcessNodes(node);
+}
+
+void YamlPreprocessor::ProcessNodes(YAML::Node &node) {
+  switch (node.Type()) {
+    case YAML::NodeType::Sequence:
+      for (YAML::Node child : node){
+        YamlPreprocessor::ProcessNodes(child);
+      }
+      break;
+    case YAML::NodeType::Map:
+      for(YAML::iterator it=node.begin();it!=node.end();++it) {
+        YamlPreprocessor::ProcessNodes(it->second);
+      }
+      break;
+    case YAML::NodeType::Scalar:
+      ROS_INFO_STREAM("Scalar: " << node.as<std::string>());
+      if (node.as<std::string>().compare(0, 5, "$eval") == 0) {
+        ROS_WARN_STREAM("Found $eval");
+        ProcessScalarNode(node);
+      }
+      break;
+  }
+}
+
+void YamlPreprocessor::ProcessScalarNode(YAML::Node &node) {
+  std::string value = node.as<std::string>().substr(5);  //omit the $parse
+  boost::algorithm::trim(value); //trim whitespace
+
+  
+  if (value.find("return ") == std::string::npos) {  // Has no return statement
+    value = "return " + value;
+  }
+
+  ROS_WARN_STREAM(value);
+
+  // Create the Lua context
+  lua_State *L = luaL_newstate();
+  luaL_openlibs(L);
+  lua_pushcfunction(L, YamlPreprocessor::LuaGetEnv);
+  lua_setglobal(L, "env");
+  lua_pushcfunction(L, YamlPreprocessor::LuaGetParam);
+  lua_setglobal(L, "param");
+
+  int error = luaL_dostring(L, value.c_str());
+  if (error) {
+    ROS_ERROR_STREAM(lua_tostring(L, -1));
+    lua_pop(L, 1);  /* pop error message from the stack */
+  } else {
+    int t = lua_type(L, 1);
+    if ( t == LUA_TNIL ) {
+      ROS_ERROR_STREAM("NULL result");
+    } else {
+      ROS_ERROR_STREAM("result: " << lua_tostring(L, 1));
+    }
+    
+  }
+}
+
+YAML::Node YamlPreprocessor::LoadParse(const std::string &path) {
+  YAML::Node node;
+
+  try {
+    node = YAML::LoadFile(path);
+  } catch (const YAML::BadFile &e) {
+    throw YAMLException("File does not exist, path=" + path);
+  } catch (const YAML::ParserException &e) {
+    throw YAMLException("Malformatted file, path=" + path, e);
+  } catch (const YAML::Exception &e) {
+    throw YAMLException("Error loading file, path=" + path, e);
+  }
+
+  YamlPreprocessor::Parse(node);
+  return node;
+}
+
+int YamlPreprocessor::LuaGetEnv(lua_State *L) {
+  const char *name = lua_tostring(L, 1);
+  const char* env = std::getenv(name);
+
+  if (lua_gettop(L) == 2) {  // default passed in
+    if (lua_isnumber(L, 2)) {
+      if (env == NULL) {
+        lua_pushnumber(L, lua_tonumber(L, 2));
+      } else {
+        lua_pushnumber(L, std::atof(env));
+      }
+    } else if (lua_isstring(L, 2)) {
+      if (env == NULL) {
+        lua_pushstring(L, lua_tostring(L, 2));
+      } else {
+        lua_pushstring(L, env);
+      }
+    }
+  } else {  // no default
+    if (env == NULL) {  // Push back a nil
+      ROS_ERROR_STREAM("No environment variable for: " << name);
+      lua_pushnil(L); 
+    } else {
+      try {  // Try to push a number
+        double x = boost::lexical_cast<double>(env);
+        ROS_ERROR_STREAM("Assuming number for: " << name);
+        lua_pushnumber(L, x);
+      } catch(boost::bad_lexical_cast&) {  // Otherwise it's a string
+        ROS_ERROR_STREAM("Assuming string for: " << name);
+        lua_pushstring(L,env);
+      }
+    }
+  }
+
+  return 1;  // 1 return value
+}
+
+int YamlPreprocessor::LuaGetParam(lua_State *L) {
+  const char *name = lua_tostring(L, 1);
+  std::string param;
+  ros::param::param<std::string>(name, param, "default_value");
+
+  if (lua_gettop(L) == 2) {  // default value was passed in
+    if (lua_isnumber(L, 2)) {
+      if (!ros::param::has(name)) {  // return default
+        lua_pushnumber(L, lua_tonumber(L, 2));
+      } else {
+        lua_pushnumber(L, std::atof(param.c_str()));
+      }
+    } else if (lua_isstring(L, 2)) {
+      if (!ros::param::has(name)) {  // return default
+        lua_pushstring(L, lua_tostring(L, 2));
+      } else {
+        lua_pushstring(L, param.c_str());
+      }
+    }
+  } else {  // no default
+    if (!ros::param::has(name)) {  // Push back a nil
+      ROS_ERROR_STREAM("No environment variable for: " << name);
+      lua_pushnil(L); 
+    } else {
+      try {  // Try to push a number
+        double x = boost::lexical_cast<double>(param.c_str());
+        ROS_ERROR_STREAM("Assuming number for: " << name);
+        lua_pushnumber(L, x);
+      } catch(boost::bad_lexical_cast&) {  // Otherwise it's a string
+        ROS_ERROR_STREAM("Assuming string for: " << name);
+        lua_pushstring(L, param.c_str());
+      }
+    }
+  }
+
+  return 1;  // 1 return value
+}
+
+}

--- a/flatland_server/src/yaml_reader.cpp
+++ b/flatland_server/src/yaml_reader.cpp
@@ -44,6 +44,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <flatland_server/yaml_preprocessor.h>
 #include <flatland_server/yaml_reader.h>
 #include <boost/filesystem/path.hpp>
 
@@ -54,12 +55,14 @@ YamlReader::YamlReader() : node_(YAML::Node()) {
 }
 
 YamlReader::YamlReader(const YAML::Node &node) : node_(node) {
+  YamlPreprocessor::Parse(node_);
   SetErrorInfo("_NONE_", "_NONE_");
 }
 
 YamlReader::YamlReader(const std::string &path) {
   try {
     node_ = YAML::LoadFile(path);
+    YamlPreprocessor::Parse(node_);
   } catch (const YAML::BadFile &e) {
     throw YAMLException("File does not exist, path=" + Q(path));
 

--- a/flatland_server/test/yaml_preprocessor/yaml/eval.strings.out.yaml
+++ b/flatland_server/test/yaml_preprocessor/yaml/eval.strings.out.yaml
@@ -1,0 +1,30 @@
+foo: Hello World
+bar: Hello World
+baz: Hello World
+bash: 1234
+boop:
+  bal: 12.34
+foop:
+ - A
+ - B
+ - C
+bom: |
+  Some
+  multiline
+  string
+testEnv:
+  env1: Bar
+  env2: 123.4
+  env3: Bar
+  env4: 123.4
+  env5: null
+  env6: 444.4
+  env7: ZZZ
+testParam:
+  param1: Foo
+  param2: 10.0
+  param3: Foo
+  param4: 10.0
+  param5: null
+  param6: 223
+  param7: BBBC

--- a/flatland_server/test/yaml_preprocessor/yaml/eval.strings.out.yaml
+++ b/flatland_server/test/yaml_preprocessor/yaml/eval.strings.out.yaml
@@ -20,6 +20,7 @@ testEnv:
   env5: ""
   env6: 444.4
   env7: ZZZ
+  env8: true
 testParam:
   param1: Foo
   param2: 7
@@ -28,3 +29,5 @@ testParam:
   param5: ""
   param6: 223
   param7: BBBC
+  param8: true
+  param9: true

--- a/flatland_server/test/yaml_preprocessor/yaml/eval.strings.out.yaml
+++ b/flatland_server/test/yaml_preprocessor/yaml/eval.strings.out.yaml
@@ -17,14 +17,14 @@ testEnv:
   env2: 123.4
   env3: Bar
   env4: 123.4
-  env5: null
+  env5: ""
   env6: 444.4
   env7: ZZZ
 testParam:
   param1: Foo
-  param2: 10.0
+  param2: 7
   param3: Foo
-  param4: 10.0
-  param5: null
+  param4: 10.5
+  param5: ""
   param6: 223
   param7: BBBC

--- a/flatland_server/test/yaml_preprocessor/yaml/eval.strings.yaml
+++ b/flatland_server/test/yaml_preprocessor/yaml/eval.strings.yaml
@@ -12,7 +12,8 @@ bom: |
   $eval
   [[Some
   multiline
-  string]]
+  string
+  ]]
 testEnv:
   env1: $eval env("VALIDSTRING")
   env2: $eval env("VALIDNUMBER")
@@ -23,9 +24,9 @@ testEnv:
   env7: $eval env("INVALID","ZZZ")
 testParam:
   param1: $eval param("/string")
-  param2: $eval param("/number")
+  param2: $eval param("/int")
   param3: $eval param("/string","AAA")
-  param4: $eval param("/number","111")
+  param4: $eval param("/float","111")
   param5: $eval param("/invalid")
   param6: $eval param("/invalid","222")+1
   param7: $eval param("/invalid","BBB").."C"

--- a/flatland_server/test/yaml_preprocessor/yaml/eval.strings.yaml
+++ b/flatland_server/test/yaml_preprocessor/yaml/eval.strings.yaml
@@ -22,7 +22,7 @@ testEnv:
   env5: $eval env("INVALID")
   env6: $eval env("INVALID","444.4")
   env7: $eval env("INVALID","ZZZ")
-  env8: $eval param("INVALID", true)
+  env8: $eval env("INVALID", true)
 
 testParam:
   param1: $eval param("/string")

--- a/flatland_server/test/yaml_preprocessor/yaml/eval.strings.yaml
+++ b/flatland_server/test/yaml_preprocessor/yaml/eval.strings.yaml
@@ -22,6 +22,8 @@ testEnv:
   env5: $eval env("INVALID")
   env6: $eval env("INVALID","444.4")
   env7: $eval env("INVALID","ZZZ")
+  env8: $eval param("INVALID", true)
+
 testParam:
   param1: $eval param("/string")
   param2: $eval param("/int")
@@ -30,3 +32,5 @@ testParam:
   param5: $eval param("/invalid")
   param6: $eval param("/invalid","222")+1
   param7: $eval param("/invalid","BBB").."C"
+  param8: $eval param("/invalid", true)
+  param9: $eval true

--- a/flatland_server/test/yaml_preprocessor/yaml/eval.strings.yaml
+++ b/flatland_server/test/yaml_preprocessor/yaml/eval.strings.yaml
@@ -1,0 +1,31 @@
+foo: $eval return "Hello World"
+bar: $eval return string.gsub("Hello banana", "banana", "World")
+baz: $eval string.gsub("Hello banana", "banana", "World")
+bash: $eval 1234
+boop:
+  bal: $eval 12.34
+foop:
+ - A
+ - $eval "B"
+ - C
+bom: |
+  $eval
+  [[Some
+  multiline
+  string]]
+testEnv:
+  env1: $eval env("VALIDSTRING")
+  env2: $eval env("VALIDNUMBER")
+  env3: $eval env("VALIDSTRING","YYY")
+  env4: $eval env("VALIDNUMBER","333.3")
+  env5: $eval env("INVALID")
+  env6: $eval env("INVALID","444.4")
+  env7: $eval env("INVALID","ZZZ")
+testParam:
+  param1: $eval param("/string")
+  param2: $eval param("/number")
+  param3: $eval param("/string","AAA")
+  param4: $eval param("/number","111")
+  param5: $eval param("/invalid")
+  param6: $eval param("/invalid","222")+1
+  param7: $eval param("/invalid","BBB").."C"

--- a/flatland_server/test/yaml_preprocessor/yaml_preprocessor_test.cpp
+++ b/flatland_server/test/yaml_preprocessor/yaml_preprocessor_test.cpp
@@ -52,6 +52,37 @@
 namespace fs = boost::filesystem;
 using namespace flatland_server;
 
+void compareNodes(const char *p1, YAML::Node &a, YAML::Node &b) {
+  try {
+    EXPECT_STREQ(b[p1].as<std::string>().c_str(),
+                 a[p1].as<std::string>().c_str())
+        << "at " << p1;
+  } catch (...) {
+    ADD_FAILURE() << "Failure to compare " << p1;
+  }
+}
+
+void compareNodes(const char *p1, int p2, YAML::Node &a, YAML::Node &b) {
+  try {
+    EXPECT_STREQ(b[p1][p2].as<std::string>().c_str(),
+                 a[p1][p2].as<std::string>().c_str())
+        << "at " << p1 << ":" << p2;
+  } catch (...) {
+    ADD_FAILURE() << "Failure to compare " << p1 << ":" << p2;
+  }
+}
+
+void compareNodes(const char *p1, const char *p2, YAML::Node &a,
+                  YAML::Node &b) {
+  try {
+    EXPECT_STREQ(b[p1][p2].as<std::string>().c_str(),
+                 a[p1][p2].as<std::string>().c_str())
+        << "at " << p1 << ":" << p2;
+  } catch (...) {
+    ADD_FAILURE() << "Failure to compare " << p1 << ":" << p2;
+  }
+}
+
 // Test the bodyToMarkers method on a polygon shape
 TEST(YamlPreprocTest, testEvalStrings) {
   boost::filesystem::path cwd = fs::path(__FILE__).parent_path();
@@ -59,12 +90,42 @@ TEST(YamlPreprocTest, testEvalStrings) {
   YAML::Node in = YamlPreprocessor::LoadParse(
       (cwd / fs::path("/yaml/eval.strings.yaml")).string());
 
-  // check that marker was created
-  ASSERT_EQ(1, 1);
+  YAML::Node out = YamlPreprocessor::LoadParse(
+      (cwd / fs::path("/yaml/eval.strings.out.yaml")).string());
+
+  // check that the two strings match
+  compareNodes("foo", in, out);
+  compareNodes("bar", in, out);
+  compareNodes("baz", in, out);
+  compareNodes("bash", in, out);
+
+  compareNodes("boop", "bal", in, out);
+
+  compareNodes("foop", 0, in, out);
+  compareNodes("foop", 1, in, out);
+  compareNodes("foop", 2, in, out);
+
+  compareNodes("bom", in, out);
+
+  compareNodes("testEnv", "env1", in, out);
+  compareNodes("testEnv", "env2", in, out);
+  compareNodes("testEnv", "env3", in, out);
+  compareNodes("testEnv", "env4", in, out);
+  compareNodes("testEnv", "env5", in, out);
+  compareNodes("testEnv", "env6", in, out);
+  compareNodes("testEnv", "env7", in, out);
+
+  compareNodes("testParam", "param1", in, out);
+  compareNodes("testParam", "param2", in, out);
+  compareNodes("testParam", "param3", in, out);
+  compareNodes("testParam", "param4", in, out);
+  compareNodes("testParam", "param5", in, out);
+  compareNodes("testParam", "param6", in, out);
+  compareNodes("testParam", "param7", in, out);
 }
 
 // Run all the tests that were declared with TEST()
-int main(int argc, char** argv) {
+int main(int argc, char **argv) {
   ros::init(argc, argv, "yaml_preprocessor_test");
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/flatland_server/test/yaml_preprocessor/yaml_preprocessor_test.cpp
+++ b/flatland_server/test/yaml_preprocessor/yaml_preprocessor_test.cpp
@@ -114,6 +114,7 @@ TEST(YamlPreprocTest, testEvalStrings) {
   compareNodes("testEnv", "env5", in, out);
   compareNodes("testEnv", "env6", in, out);
   compareNodes("testEnv", "env7", in, out);
+  compareNodes("testEnv", "env8", in, out);
 
   compareNodes("testParam", "param1", in, out);
   compareNodes("testParam", "param2", in, out);
@@ -122,6 +123,8 @@ TEST(YamlPreprocTest, testEvalStrings) {
   compareNodes("testParam", "param5", in, out);
   compareNodes("testParam", "param6", in, out);
   compareNodes("testParam", "param7", in, out);
+  compareNodes("testParam", "param8", in, out);
+  compareNodes("testParam", "param9", in, out);
 }
 
 // Run all the tests that were declared with TEST()

--- a/flatland_server/test/yaml_preprocessor/yaml_preprocessor_test.cpp
+++ b/flatland_server/test/yaml_preprocessor/yaml_preprocessor_test.cpp
@@ -1,0 +1,71 @@
+/*
+ *  ______                   __  __              __
+ * /\  _  \           __    /\ \/\ \            /\ \__
+ * \ \ \L\ \  __  __ /\_\   \_\ \ \ \____    ___\ \ ,_\   ____
+ *  \ \  __ \/\ \/\ \\/\ \  /'_` \ \ '__`\  / __`\ \ \/  /',__\
+ *   \ \ \/\ \ \ \_/ |\ \ \/\ \L\ \ \ \L\ \/\ \L\ \ \ \_/\__, `\
+ *    \ \_\ \_\ \___/  \ \_\ \___,_\ \_,__/\ \____/\ \__\/\____/
+ *     \/_/\/_/\/__/    \/_/\/__,_ /\/___/  \/___/  \/__/\/___/
+ * @copyright Copyright 2017 Avidbots Corp.
+ * @name	null.cpp
+ * @brief	Sanity check / example test file
+ * @author Joseph Duchesne
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, Avidbots Corp.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Avidbots Corp. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "flatland_server/yaml_preprocessor.h"
+#include <gtest/gtest.h>
+#include <ros/ros.h>
+#include <cmath>
+
+namespace fs = boost::filesystem;
+using namespace flatland_server;
+
+// Test the bodyToMarkers method on a polygon shape
+TEST(YamlPreprocTest, testEvalStrings) {
+
+  boost::filesystem::path cwd = fs::path(__FILE__).parent_path();
+  
+  YAML::Node in = YamlPreprocessor::LoadParse((cwd / fs::path("/yaml/eval.strings.yaml")).string());
+
+  // check that marker was created
+  ASSERT_EQ(1, 1);
+}
+
+// Run all the tests that were declared with TEST()
+int main(int argc, char** argv) {
+  ros::init(argc, argv, "yaml_preprocessor_test");
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/flatland_server/test/yaml_preprocessor/yaml_preprocessor_test.cpp
+++ b/flatland_server/test/yaml_preprocessor/yaml_preprocessor_test.cpp
@@ -54,10 +54,10 @@ using namespace flatland_server;
 
 // Test the bodyToMarkers method on a polygon shape
 TEST(YamlPreprocTest, testEvalStrings) {
-
   boost::filesystem::path cwd = fs::path(__FILE__).parent_path();
-  
-  YAML::Node in = YamlPreprocessor::LoadParse((cwd / fs::path("/yaml/eval.strings.yaml")).string());
+
+  YAML::Node in = YamlPreprocessor::LoadParse(
+      (cwd / fs::path("/yaml/eval.strings.yaml")).string());
 
   // check that marker was created
   ASSERT_EQ(1, 1);

--- a/flatland_server/test/yaml_preprocessor/yaml_preprocessor_test.test
+++ b/flatland_server/test/yaml_preprocessor/yaml_preprocessor_test.test
@@ -1,0 +1,13 @@
+<!--
+Test launchfile for yaml_preprocessor_test
+
+This file tests that the preprocessor handles all manner of conditionals and statements
+-->
+<launch>
+  <test pkg="flatland_server" type="yaml_preprocessor_test" test-name="yaml_preprocessor_test">
+    <env name="VALIDSTRING" value="Bar"/>
+    <env name="VALIDNUMBER" value="123.4"/>
+    <param name="/string" value="Foo"/>
+    <param name="/number" value="10.0"/>
+  </test>
+</launch>

--- a/flatland_server/test/yaml_preprocessor/yaml_preprocessor_test.test
+++ b/flatland_server/test/yaml_preprocessor/yaml_preprocessor_test.test
@@ -4,10 +4,12 @@ Test launchfile for yaml_preprocessor_test
 This file tests that the preprocessor handles all manner of conditionals and statements
 -->
 <launch>
+  <param name="/string" value="Foo" type="str" />
+  <param name="/int" value="7" type="int" />
+  <param name="/float" value="10.5" type="double" />
+
   <test pkg="flatland_server" type="yaml_preprocessor_test" test-name="yaml_preprocessor_test">
     <env name="VALIDSTRING" value="Bar"/>
     <env name="VALIDNUMBER" value="123.4"/>
-    <param name="/string" value="Foo"/>
-    <param name="/number" value="10.0"/>
   </test>
 </launch>


### PR DESCRIPTION
Added a lua preprocessor for YAML with simple bindings for the environment variables and rosparam.
The intent is to be able to build parametric models that are defined by dimensions and flags found in either environment variables or rosparam, in a similar way to xacro+urdf. Because this is parsed at model load time, any roslaunch rosparam loading will have completed and those parameters will be available.

Documentation: https://flatland-simulator.readthedocs.io/en/lua-preprocessor-for-yaml/core_functions/yaml_preprocessor.html