### PR TITLE
Fixes #52 Added "collision" flag to footprint to allow disabling collision

### DIFF
--- a/docs/core_functions/models.rst
+++ b/docs/core_functions/models.rst
@@ -58,6 +58,11 @@ shown here. Examples can be found in flatland_server/tests.
           # between objects in the same layer, used for all footprint types
           layers: ["all"]
 
+          # optional, defaults to true
+          # If set to "false" entirely disables collision with this object
+          # Does not disable interactions like the laser scan plugin.
+          collision: true
+
           # required, the density of footprint in kg/m^2 in Box2D, used for all
           # footprint types
           density: 1

--- a/flatland_plugins/include/flatland_plugins/laser.h
+++ b/flatland_plugins/include/flatland_plugins/laser.h
@@ -54,8 +54,8 @@
 #include <thirdparty/ThreadPool.h>
 #include <visualization_msgs/Marker.h>
 #include <Eigen/Dense>
-#include <thread>
 #include <random>
+#include <thread>
 
 #ifndef FLATLAND_PLUGINS_LASER_H
 #define FLATLAND_PLUGINS_LASER_H

--- a/flatland_server/src/model_body.cpp
+++ b/flatland_server/src/model_body.cpp
@@ -149,7 +149,14 @@ void ModelBody::ConfigFootprintDef(YamlReader &footprint_reader,
                         "} layer(s) does not exist");
   }
 
-  fixture_def.filter.maskBits = fixture_def.filter.categoryBits;
+  bool collision = footprint_reader.Get<bool>("collision", true);
+  if (collision) {
+    // b2d docs: maskBits are "I collide with" bitmask
+    fixture_def.filter.maskBits = fixture_def.filter.categoryBits;
+  } else {
+    // "I will collide with nothing"
+    fixture_def.filter.maskBits = 0;
+  }
 }
 
 void ModelBody::LoadCircleFootprint(YamlReader &footprint_reader) {


### PR DESCRIPTION
To use this you'll have to add "collision: false" to each footprint on the bodies of the model file that you want to not collide. 