### PR TITLE
ROS2

### DIFF
--- a/flatland_plugins/CMakeLists.txt
+++ b/flatland_plugins/CMakeLists.txt
@@ -97,6 +97,8 @@ ament_export_targets(export_flatland_plugins_lib HAS_LIBRARY_TARGET)
 # ament_export_libraries(flatland_lib)
 ament_export_dependencies(rclcpp flatland_server flatland_msgs pluginlib geometry_msgs tf2 tf2_ros tf2_geometry_msgs yaml_cpp_vendor)
 
+ament_package()
+
 #############
 ## Install ##
 #############
@@ -168,5 +170,3 @@ if(BUILD_TESTING )
 
 endif()
 endif()
-
-ament_package()

--- a/flatland_plugins/CMakeLists.txt
+++ b/flatland_plugins/CMakeLists.txt
@@ -97,8 +97,6 @@ ament_export_targets(export_flatland_plugins_lib HAS_LIBRARY_TARGET)
 # ament_export_libraries(flatland_lib)
 ament_export_dependencies(rclcpp flatland_server flatland_msgs pluginlib geometry_msgs tf2 tf2_ros tf2_geometry_msgs yaml_cpp_vendor)
 
-ament_package()
-
 #############
 ## Install ##
 #############
@@ -170,3 +168,5 @@ if(BUILD_TESTING )
 
 endif()
 endif()
+
+ament_package()

--- a/flatland_plugins/CMakeLists.txt
+++ b/flatland_plugins/CMakeLists.txt
@@ -29,11 +29,19 @@ find_package(tf2_geometry_msgs REQUIRED)
 find_package(flatland_server REQUIRED)
 find_package(flatland_msgs REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
+find_package(visualization_msgs REQUIRED)
+find_package(interactive_markers REQUIRED)
 #  rostest
 
 
 find_package(Eigen3 REQUIRED)# lua5.1
 find_package(Lua 5.1 QUIET)
+
+# Boost
+find_package(Boost REQUIRED COMPONENTS date_time system filesystem)
+
+# OpenCV
+find_package(OpenCV REQUIRED)
 
 ##############
 ## coverage ##
@@ -81,13 +89,13 @@ target_include_directories(flatland_plugins_lib PUBLIC
 target_link_libraries(flatland_plugins_lib
   ${Eigen3_LIBRARIES}
   ${LUA_LIBRARIES}
+  ${OpenCV_LIBRARIES}
   yaml-cpp
 )
 
-ament_export_interfaces(export_flatland_plugins_lib HAS_LIBRARY_TARGET)
+ament_export_targets(export_flatland_plugins_lib HAS_LIBRARY_TARGET)
 # ament_export_libraries(flatland_lib)
 ament_export_dependencies(rclcpp flatland_server flatland_msgs pluginlib geometry_msgs tf2 tf2_ros tf2_geometry_msgs yaml_cpp_vendor)
-ament_package()
 
 #############
 ## Install ##
@@ -160,3 +168,5 @@ if(BUILD_TESTING )
 
 endif()
 endif()
+
+ament_package()

--- a/flatland_plugins/include/flatland_plugins/diff_drive.h
+++ b/flatland_plugins/include/flatland_plugins/diff_drive.h
@@ -68,7 +68,7 @@ class DiffDrive : public flatland_server::ModelPlugin {
   rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr ground_truth_pub_;
   rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr twist_pub_;
   Body* body_;
-  geometry_msgs::msg::Twist::SharedPtr twist_msg_;
+  geometry_msgs::msg::Twist::SharedPtr twist_msg_ = std::make_shared<geometry_msgs::msg::Twist>();
   nav_msgs::msg::Odometry odom_msg_;
   nav_msgs::msg::Odometry ground_truth_msg_;
   UpdateTimer update_timer_;

--- a/flatland_plugins/include/flatland_plugins/tricycle_drive.h
+++ b/flatland_plugins/include/flatland_plugins/tricycle_drive.h
@@ -78,7 +78,7 @@ class TricycleDrive : public flatland_server::ModelPlugin {
   double delta_;          ///< The current angular offset of the front wheel
   double d_delta_;        ///< The current angular speed of the front wheel
 
-  geometry_msgs::msg::Twist::SharedPtr twist_msg_;
+  geometry_msgs::msg::Twist::SharedPtr twist_msg_ = std::make_shared<geometry_msgs::msg::Twist>();
   nav_msgs::msg::Odometry odom_msg_;
   nav_msgs::msg::Odometry ground_truth_msg_;
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr twist_sub_;

--- a/flatland_plugins/package.xml
+++ b/flatland_plugins/package.xml
@@ -28,6 +28,11 @@
   <depend>flatland_msgs</depend>
   <depend>flatland_server</depend>
   <depend>lua-dev</depend>
+  <depend>visualization_msgs</depend>
+  <depend>interactive_markers</depend>
+  <depend>libboost-date-time-dev</depend>
+  <depend>libboost-filesystem-dev</depend>
+  <depend>libboost-dev</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/flatland_server/CMakeLists.txt
+++ b/flatland_server/CMakeLists.txt
@@ -196,9 +196,6 @@ if(FALSE) # fake a block comment
 endif()
 endif()
 
-
-ament_package()
-
 #############
 ## Install ##
 #############
@@ -234,6 +231,4 @@ install(DIRECTORY test/conestogo_office_test
     DESTINATION share/${PROJECT_NAME}/test
 )
 
-
-# Install plugins file
-pluginlib_export_plugin_description_file(flatland_lib plugin_description.xml)
+ament_package()

--- a/flatland_server/CMakeLists.txt
+++ b/flatland_server/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
 find_package(visualization_msgs REQUIRED)
 find_package(interactive_markers REQUIRED)
 find_package(flatland_msgs REQUIRED)
@@ -90,7 +91,7 @@ target_include_directories(flatland_lib
     $<INSTALL_INTERFACE:include>
     ${LUA_INCLUDE_DIR})
 
-ament_target_dependencies(flatland_lib rclcpp flatland_msgs yaml_cpp_vendor pluginlib geometry_msgs std_srvs tf2 tf2_ros tf2_geometry_msgs visualization_msgs interactive_markers)
+ament_target_dependencies(flatland_lib rclcpp flatland_msgs yaml_cpp_vendor pluginlib geometry_msgs std_srvs tf2 tf2_ros tf2_geometry_msgs visualization_msgs interactive_markers sensor_msgs)
 
 target_link_libraries(flatland_lib
   ${OpenCV_LIBRARIES}
@@ -124,9 +125,9 @@ target_link_libraries(flatland_server
 )
 
 
-ament_export_interfaces(flatland_lib HAS_LIBRARY_TARGET)
+ament_export_targets(flatland_lib HAS_LIBRARY_TARGET)
 ament_export_libraries(flatland_lib)
-ament_export_dependencies(rclcpp flatland_msgs yaml_cpp_vendor pluginlib geometry_msgs std_srvs tf2 tf2_ros tf2_geometry_msgs)
+ament_export_dependencies(rclcpp flatland_msgs yaml_cpp_vendor pluginlib geometry_msgs std_srvs tf2 tf2_ros tf2_geometry_msgs sensor_msgs)
 ament_export_include_directories(include)
 
 

--- a/flatland_server/package.xml
+++ b/flatland_server/package.xml
@@ -23,6 +23,7 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>geometry_msgs</depend>
+  <depend>sensor_msgs</depend>
   <depend>yaml_cpp_vendor</depend>
   <depend>visualization_msgs</depend>
   <depend>interactive_markers</depend>

--- a/flatland_server/src/flatland_server_node.cpp
+++ b/flatland_server/src/flatland_server_node.cpp
@@ -66,8 +66,8 @@
 //     delete simulation_manager;
 //     simulation_manager = nullptr;
 //   }
-//   ROS_INFO_STREAM_NAMED("Node", "Beginning ros shutdown");
-//   ros::shutdown();
+//   RCLCPP_INFO_STREAM_NAMED("Node", "Beginning ros shutdown");
+//   rclcpp::shutdown();
 // }
 
 class FlatlandServerNode : public rclcpp::Node
@@ -90,7 +90,7 @@ class FlatlandServerNode : public rclcpp::Node
       }
       get_parameter_or("update_rate", update_rate_, 200.0f);
       get_parameter_or("step_size", step_size_, 1.0f/200.0f);
-      get_parameter_or("show_viz", show_viz_, 0.0f);
+      get_parameter_or("show_viz", show_viz_, false);
       get_parameter_or("viz_pub_rate", viz_pub_rate_, 30.0f);
     }
 
@@ -112,7 +112,7 @@ class FlatlandServerNode : public rclcpp::Node
     std::string world_path_; // The file path to the world.yaml file
     float update_rate_;  // The physics update rate (Hz)
     float step_size_;
-    float show_viz_;
+    bool show_viz_;
     float viz_pub_rate_;
     std::shared_ptr<flatland_server::SimulationManager> simulation_manager_;
 };

--- a/flatland_server/src/layer.cpp
+++ b/flatland_server/src/layer.cpp
@@ -162,7 +162,7 @@ Layer *Layer::MakeLayer(std::shared_ptr<rclcpp::Node> node, b2World *physics_wor
       RCLCPP_INFO(rclcpp::get_logger("Layer"), "layer \"%s\" loading image from path=\"%s\"",
                      names[0].c_str(), image_path.string().c_str());
 
-      cv::Mat map = cv::imread(image_path.string(), CV_LOAD_IMAGE_GRAYSCALE);
+      cv::Mat map = cv::imread(image_path.string(), cv::ImreadModes::IMREAD_GRAYSCALE );
       if (map.empty()) {
         throw YAMLException("Failed to load " + Q(image_path.string()) +
                             " in layer " + Q(names[0]));

--- a/flatland_server/src/world.cpp
+++ b/flatland_server/src/world.cpp
@@ -108,7 +108,7 @@ void World::Update(Timekeeper &timekeeper) {
     timekeeper.StepTime();
     plugin_manager_.AfterPhysicsStep(timekeeper);
   }
-  //int_marker_manager_.update();
+  int_marker_manager_.update();
 }
 
 void World::BeginContact(b2Contact *contact) {
@@ -301,7 +301,7 @@ void World::DeleteModel(const std::string &name) {
       plugin_manager_.DeleteModelPlugin(models_[i]);
       delete models_[i];
       models_.erase(models_.begin() + i);
-      //int_marker_manager_.deleteInteractiveMarker(name);
+      int_marker_manager_.deleteInteractiveMarker(name);
       found = true;
       break;
     }

--- a/flatland_server/thirdparty/Box2D/CMakeLists.txt
+++ b/flatland_server/thirdparty/Box2D/CMakeLists.txt
@@ -146,7 +146,7 @@ set_target_properties(flatland_Box2D PROPERTIES
 	GIT_COMMIT_HASH f655c603ba9d83f07fc566d38d2654ba35739102
 )
 
-ament_export_interfaces(export_flatland_Box2D HAS_LIBRARY_TARGET)
+ament_export_targets(export_flatland_Box2D HAS_LIBRARY_TARGET)
 install( 
   TARGETS flatland_Box2D
   EXPORT export_flatland_Box2D

--- a/flatland_viz/CMakeLists.txt
+++ b/flatland_viz/CMakeLists.txt
@@ -1,41 +1,45 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(flatland_viz)
 
-# Get the LSB release name (14.04 or 16.04) string into variable ${LSB_RELEASE_VALUE}
-FIND_PROGRAM(LSB_RELEASE_EXECUTABLE lsb_release)
-EXECUTE_PROCESS(COMMAND ${LSB_RELEASE_EXECUTABLE} -s -r
-          OUTPUT_VARIABLE LSB_RELEASE_VALUE
-          OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-if(${LSB_RELEASE_VALUE} STREQUAL "14.04")
-message("Skipping flatland_viz because it is incompatible with 14.04")
-return()
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
 endif()
 
-# Ensure we're using c++11
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
 
-## Find catkin macros and libraries
+## Find macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS
-  rostest
-  roscpp
-  rviz
-  flatland_server
-  flatland_msgs
-)
+
+find_package(ament_cmake REQUIRED)
+
+find_package(rclcpp REQUIRED)  
+find_package(rviz2 REQUIRED)
+find_package(rviz_common REQUIRED)
+find_package(rviz_rendering REQUIRED)
+find_package(rviz_default_plugins REQUIRED)
+find_package(std_srvs REQUIRED)
+find_package(flatland_server REQUIRED)
+find_package(flatland_msgs REQUIRED)
+find_package(visualization_msgs REQUIRED)
+find_package(interactive_markers REQUIRED)
+
+# Boost
+find_package(Boost REQUIRED COMPONENTS date_time system filesystem)
 
 ##############
 ## coverage ##
 ##############
 
-set(COVERAGE "OFF" CACHE STRING "Enable coverage generation.")
+#set(COVERAGE "OFF" CACHE STRING "Enable coverage generation.")
 
-message(STATUS "Using COVERAGE: ${COVERAGE}")
-if("${COVERAGE}" STREQUAL "ON")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-arcs -ftest-coverage")
-endif()
+#message(STATUS "Using COVERAGE: ${COVERAGE}")
+#if("${COVERAGE}" STREQUAL "ON")
+#    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-arcs -ftest-coverage")
+#endif()
 
 ########################
 ## Ogre Include Stuff ##
@@ -55,35 +59,31 @@ endif(NOT OGRE_OV_FOUND)
 ###################################
 ## catkin specific configuration ##
 ###################################
-catkin_package(
-  INCLUDE_DIRS include ${OGRE_OV_INCLUDE_DIRS}
-  CATKIN_DEPENDS roscpp rviz flatland_server
-)
+#catkin_package(
+#  INCLUDE_DIRS include ${OGRE_OV_INCLUDE_DIRS}
+#  CATKIN_DEPENDS roscpp rviz flatland_server
+#)
 
 
 ###########
 ## Build ##
 ###########
 
-include_directories(include ${catkin_INCLUDE_DIRS} ${OGRE_OV_INCLUDE_DIRS})
-link_directories(${catkin_LIBRARY_DIRS})
+include_directories(include ${OGRE_OV_INCLUDE_DIRS})
+
+
+
+#link_directories(${catkin_LIBRARY_DIRS})
 
 ## This setting causes Qt's "MOC" generation to happen automatically.
 set(CMAKE_AUTOMOC ON)
 
 ## This plugin includes Qt widgets, so we must include Qt.
 ## We'll use the version that rviz used so they are compatible.
-if(rviz_QT_VERSION VERSION_LESS "5")
-  message(STATUS "Using Qt4 based on the rviz_QT_VERSION: ${rviz_QT_VERSION}")
-  find_package(Qt4 ${rviz_QT_VERSION} EXACT REQUIRED QtCore QtGui)
-  ## pull in all required include dirs, define QT_LIBRARIES, etc.
-  include(${QT_USE_FILE})
-else()
-  message(STATUS "Using Qt5 based on the rviz_QT_VERSION: ${rviz_QT_VERSION}")
-  find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Widgets)
-  ## make target_link_libraries(${QT_LIBRARIES}) pull in all required dependencies
-  set(QT_LIBRARIES Qt5::Widgets)
-endif()
+message(STATUS "Using Qt5 based on the rviz_QT_VERSION: ${rviz_QT_VERSION}")
+find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Widgets)
+## make target_link_libraries(${QT_LIBRARIES}) pull in all required dependencies
+set(QT_LIBRARIES Qt5::Widgets)
 
 add_definitions(-DQT_NO_KEYWORDS)
 
@@ -98,14 +98,27 @@ add_executable(flatland_viz
   include/flatland_viz/load_model_dialog.h
   src/spawn_model_tool.cpp
   include/flatland_viz/spawn_model_tool.h
-  src/pause_sim_tool.cpp
-  include/flatland_viz/pause_sim_tool.h
+  src/load_model_dialog.cpp
+  include/flatland_viz/load_model_dialog.h
+  #src/pause_sim_tool.cpp
+  #include/flatland_viz/pause_sim_tool.h
 )
-add_dependencies(flatland_viz ${catkin_EXPORTED_TARGETS})
+
+target_include_directories(flatland_viz
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>    
+    ${OGRE_OV_INCLUDE_DIRS})
+
+
+#add_dependencies(flatland_viz ${catkin_EXPORTED_TARGETS})
+
+ament_target_dependencies(flatland_viz rclcpp flatland_msgs flatland_server visualization_msgs interactive_markers rviz_common rviz_rendering rviz_default_plugins std_srvs)
 
 target_link_libraries(flatland_viz
   ${QT_LIBRARIES}
-  ${catkin_LIBRARIES}
+  ${Boost_LIBRARIES}
+  ${Boost_FILESYSTEM_LIBRARY}
 )
 
 add_library(flatland_viz_plugins
@@ -113,30 +126,44 @@ add_library(flatland_viz_plugins
   include/flatland_viz/load_model_dialog.h
   src/spawn_model_tool.cpp
   include/flatland_viz/spawn_model_tool.h
-  src/pause_sim_tool.cpp
-  include/flatland_viz/pause_sim_tool.h)
+  src/load_model_dialog.cpp
+  include/flatland_viz/load_model_dialog.h
+  #src/pause_sim_tool.cpp
+  #include/flatland_viz/pause_sim_tool.h
+  )
 
-add_dependencies(flatland_viz_plugins ${catkin_EXPORTED_TARGETS})
+target_include_directories(flatland_viz_plugins
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    ${OGRE_OV_INCLUDE_DIRS})
+
+#add_dependencies(flatland_viz_plugins ${catkin_EXPORTED_TARGETS})
+ament_target_dependencies(flatland_viz_plugins rclcpp flatland_msgs flatland_server rviz_common rviz_rendering rviz_default_plugins std_srvs)
 
 target_link_libraries(flatland_viz_plugins
   ${QT_LIBRARIES}
-  ${catkin_LIBRARIES}
+  ${Boost_LIBRARIES}
+  ${Boost_FILESYSTEM_LIBRARY}
 )
+
+ament_package()
 
 #############
 ## Install ##
 #############
 
+pluginlib_export_plugin_description_file(flatland_viz plugin_description.xml)
+
 # Mark executables and/or libraries for installation
 install(TARGETS flatland_viz flatland_viz_plugins
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+  DESTINATION lib/${PROJECT_NAME}
 )
 
-install(FILES
-   plugin_description.xml
-   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# Mark cpp header files for installation
+install(
+  DIRECTORY include/
+  DESTINATION include
 )
 
 #############

--- a/flatland_viz/include/flatland_viz/flatland_viz.h
+++ b/flatland_viz/include/flatland_viz/flatland_viz.h
@@ -60,13 +60,21 @@
 #include <map>
 #include <set>
 
-#include "flatland_msgs/DebugTopicList.h"
-#include "rviz/config.h"
-#include "rviz/panel.h"
-#include "rviz/properties/property_tree_widget.h"
-#include "rviz/tool.h"
-#include "rviz/tool_manager.h"
-#include "rviz/window_manager_interface.h"
+#include "flatland_msgs/msg/debug_topic_list.hpp"
+#include <rviz_common/config.hpp>
+#include <rviz_common/panel.hpp>
+#include <rviz_common/properties/property_tree_widget.hpp>
+#include <rviz_common/tool.hpp>
+#include <rviz_common/tool_manager.hpp>
+#include <rviz_common/window_manager_interface.hpp>
+
+
+#include <rviz_common/new_object_dialog.hpp"
+#include <rviz_common/display.hpp>
+#include <rviz_common/render_panel.hpp>
+#include <rviz_common/view_manager.hpp>
+#include "rviz_common/load_resource.hpp"
+#include <rviz_common/visualization_manager.hpp>
 
 class QSplashScreen;
 class QAction;
@@ -76,7 +84,7 @@ class QDockWidget;
 class QLabel;
 class QToolButton;
 
-namespace rviz {
+namespace rviz_common {
 class PanelFactory;
 class Tool;
 class Display;
@@ -101,23 +109,23 @@ class FlatlandViz : public QWidget {
    *
    * @param msg The DebugTopicList message
    */
-  void RecieveDebugTopics(const flatland_msgs::msg::DebugTopicList& msg);
+  void RecieveDebugTopics(const flatland_msgs::msg::DebugTopicList::SharedPtr msg);
 
   /**
    * @brief Destruct
    */
   virtual ~FlatlandViz();
 
-  rviz::VisualizationManager* manager_;
+  rviz_common::VisualizationManager* manager_;
 
  private:
-  rviz::RenderPanel* render_panel_;
+  rviz_common::RenderPanel* render_panel_;
 
-  rviz::Display* grid_;
-  rviz::Display* interactive_markers_;
-  std::map<std::string, rviz::Display*> debug_displays_;
+  rviz_common::Display* grid_;
+  rviz_common::Display* interactive_markers_;
+  std::map<std::string, rviz_common::Display*> debug_displays_;
   rclcpp::Subscription<flatland_msgs::msg::DebugTopicList>::SharedPtr debug_topic_subscriber_;
-  rviz::PropertyTreeWidget* tree_widget_;
+  rviz_common::properties::PropertyTreeWidget * tree_widget_;
   FlatlandWindow* parent_;
 
   QMenu* file_menu_;
@@ -129,8 +137,8 @@ class FlatlandViz : public QWidget {
   QToolBar* toolbar_;
 
   QActionGroup* toolbar_actions_;
-  std::map<QAction*, rviz::Tool*> action_to_tool_map_;
-  std::map<rviz::Tool*, QAction*> tool_to_action_map_;
+  std::map<QAction*, rviz_common::Tool*> action_to_tool_map_;
+  std::map<rviz_common::Tool*, QAction*> tool_to_action_map_;
   bool show_choose_new_master_option_;
 
   QAction* add_tool_action_;
@@ -143,10 +151,10 @@ class FlatlandViz : public QWidget {
   void fullScreenChange(bool hidden);
 
   void setDisplayConfigModified();
-  void addTool(rviz::Tool*);
-  void removeTool(rviz::Tool*);
-  void refreshTool(rviz::Tool*);
-  void indicateToolIsCurrent(rviz::Tool*);
+  void addTool(rviz_common::Tool*);
+  void removeTool(rviz_common::Tool*);
+  void refreshTool(rviz_common::Tool*);
+  void indicateToolIsCurrent(rviz_common::Tool*);
   void onToolbarActionTriggered(QAction* action);
   void onToolbarRemoveTool(QAction* remove_tool_menu_action);
   void initToolbars();

--- a/flatland_viz/include/flatland_viz/flatland_window.h
+++ b/flatland_viz/include/flatland_viz/flatland_window.h
@@ -47,49 +47,37 @@
 // namespace rviz;
 
 #include <rclcpp/rclcpp.hpp>
+
 #include <QLabel>
 #include <QMainWindow>
 #include <QPushButton>
 #include <QWidget>
+#include <QAction>
+#include <QActionGroup>
+#include <QDesktopWidget>
+#include <QFileDialog>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QMessageBox>
+#include <QStatusBar>
+#include <QToolBar>
+#include <QToolButton>
+#include <QVBoxLayout>
+#include <QWidget>
+
 #include "flatland_viz/flatland_viz.h"
 
-#include "rviz/display.h"
-#include "rviz/display_context.h"
-#include "rviz/displays_panel.h"
-#include "rviz/env_config.h"
-#include "rviz/failed_panel.h"
-#include "rviz/help_panel.h"
-#include "rviz/load_resource.h"
-#include "rviz/loading_dialog.h"
-#include "rviz/new_object_dialog.h"
-#include "rviz/panel_dock_widget.h"
-#include "rviz/panel_factory.h"
-#include "rviz/properties/status_property.h"
-#include "rviz/render_panel.h"
-#include "rviz/screenshot_dialog.h"
-#include "rviz/selection/selection_manager.h"
-#include "rviz/selection_panel.h"
-#include "rviz/splash_screen.h"
-#include "rviz/time_panel.h"
-#include "rviz/tool.h"
-#include "rviz/tool_manager.h"
-#include "rviz/tool_properties_panel.h"
-#include "rviz/view_manager.h"
-#include "rviz/views_panel.h"
-#include "rviz/visualization_frame.h"
-#include "rviz/visualization_manager.h"
-#include "rviz/widget_geometry_change_detector.h"
-#include "rviz/yaml_config_reader.h"
-#include "rviz/yaml_config_writer.h"
+#include <rviz_common/render_panel.hpp>
+#include <rviz_common/visualization_manager.hpp>
 
 class FlatlandWindow : public QMainWindow {
   Q_OBJECT
  public:
   FlatlandWindow(QWidget* parent = 0);
-  rviz::VisualizationManager* visualization_manager_;
-  rviz::RenderPanel* render_panel_;
+  rviz_common::VisualizationManager* visualization_manager_;
+  rviz_common::RenderPanel* render_panel_;
 
-  rviz::VisualizationManager* getManager();
+  rviz_common::VisualizationManager* getManager();
 
  protected Q_SLOTS:
 

--- a/flatland_viz/include/flatland_viz/load_model_dialog.h
+++ b/flatland_viz/include/flatland_viz/load_model_dialog.h
@@ -48,20 +48,6 @@
 #ifndef LOAD_MODEL_DIALOG_H
 #define LOAD_MODEL_DIALOG_H
 
-#include <OGRE/OgreEntity.h>
-#include <OGRE/OgreSceneManager.h>
-#include <OGRE/OgreSceneNode.h>
-#include <OgreVector3.h>
-
-#include <ros/console.h>
-
-#include <rviz/geometry.h>
-#include <rviz/mesh_loader.h>
-#include <rviz/properties/float_property.h>
-#include <rviz/properties/vector_property.h>
-#include <rviz/viewport_mouse_event.h>
-#include <rviz/visualization_manager.h>
-
 // #include <QColorDialog>
 #include <QCursor>
 #include <QFileDialog>
@@ -72,6 +58,20 @@
 #include <QPushButton>
 #include <QVBoxLayout>
 #include <QWidget>
+#include <QString>
+#include <QDialog>
+
+#include <OGRE/OgreEntity.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreVector3.h>
+//#include <OgreVector3.h>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <rviz_rendering/geometry.hpp>
+#include <rviz_rendering/mesh_loader.hpp>
+
 
 #include <boost/filesystem.hpp>
 

--- a/flatland_viz/include/flatland_viz/pause_sim_tool.h
+++ b/flatland_viz/include/flatland_viz/pause_sim_tool.h
@@ -2,8 +2,8 @@
 #define PAUSE_SIM_TOOL_H
 
 #include <rclcpp/rclcpp.hpp>
-#include <rviz/tool.h>
-#include <std_srvs/Empty.h>
+#include <rviz_common/tool.hpp>
+#include <std_srvs/srv/empty.hpp>
 
 namespace flatland_viz {
 
@@ -12,7 +12,7 @@ namespace flatland_viz {
  * @brief               Rviz tool to support pausing and unpausing the
  * simulation.
  */
-class PauseSimTool : public rviz::Tool {
+class PauseSimTool : public rviz_common::Tool {
  public:
   PauseSimTool();
   ~PauseSimTool();
@@ -37,9 +37,7 @@ class PauseSimTool : public rviz::Tool {
    */
   virtual void deactivate();
 
-  ros::NodeHandle nh_;  ///< NodeHandle to call the pause toggle service
-  ros::ServiceClient
-      pause_service_;  ///< ServiceClient that calls the pause toggle service
+  rclcpp::Client<std_srvs::srv::Empty>::SharedPtr pause_service_;
 };
 }
 

--- a/flatland_viz/include/flatland_viz/spawn_model_tool.h
+++ b/flatland_viz/include/flatland_viz/spawn_model_tool.h
@@ -48,27 +48,34 @@
 #ifndef SPAWN_MODEL_TOOL_H
 #define SPAWN_MODEL_TOOL_H
 
-#include <rviz/tool.h>
+#include <rviz_common/tool.hpp>
 #include <memory>
 #include <vector>
+
+#include <rclcpp/rclcpp.hpp>
 
 #include <OGRE/OgreEntity.h>
 #include <OGRE/OgreSceneManager.h>
 #include <OGRE/OgreSceneNode.h>
-#include <OgreVector3.h>
+#include <OGRE/OgreVector3.h>
+//#include <OgreVector3.h>
 
 #include <flatland_server/yaml_reader.h>
+#include <flatland_msgs/srv/spawn_model.hpp>
+
 #include <rclcpp/rclcpp.hpp>
-#include <rviz/ogre_helpers/billboard_line.h>
-#include "rviz/ogre_helpers/arrow.h"
+#include <rviz_rendering/objects/billboard_line.hpp>
+#include <rviz_rendering/objects/arrow.hpp>
+#include "flatland_viz/load_model_dialog.h"
+
 
 namespace flatland_viz {
 /**
  * @name                SpawnModelTool
  * @brief               Every tool which can be added to the tool bar is a
- * subclass of rviz::Tool.
+ * subclass of rviz_common::Tool.
  */
-class SpawnModelTool : public rviz::Tool {
+class SpawnModelTool : public rviz_common::Tool {
   Q_OBJECT
 
  public:
@@ -119,7 +126,7 @@ class SpawnModelTool : public rviz::Tool {
    * @brief               Main loop of tool
    * @param event         Mouse event
    */
-  virtual int processMouseEvent(rviz::ViewportMouseEvent &event);
+  virtual int processMouseEvent(rviz_common::ViewportMouseEvent &event);
   /**
   * @name                SetMovingModelColor
   * @brief               Set the color of the moving model
@@ -160,10 +167,9 @@ class SpawnModelTool : public rviz::Tool {
   static QString model_name;  // base file name with path and extension removed
 
  protected:
-  rviz::Arrow *arrow_;        // Rviz 3d arrow to show axis of rotation
-  ros::NodeHandle nh;         // ros service node handle
-  ros::ServiceClient client;  // ros service client
-  std::vector<std::shared_ptr<rviz::BillboardLine>> lines_list_;
+  rviz_rendering::Arrow *arrow_;        // Rviz 3d arrow to show axis of rotation
+  rclcpp::Client<flatland_msgs::srv::SpawnModel>::SharedPtr client;
+  std::vector<std::shared_ptr<rviz_rendering::BillboardLine>> lines_list_;
 };
 
 }  // end namespace flatland_viz

--- a/flatland_viz/package.xml
+++ b/flatland_viz/package.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>flatland_viz</name>
-  <version>1.1.1</version>
+  <version>2.0.0</version>
   <description>The flatland gui and visualization</description>
   <license>BSD</license>
   <url type="website">https://bitbucket.org/avidbots/flatland</url>
@@ -18,12 +19,25 @@
   <depend>libqt5-gui</depend>
   <depend>libqt5-widgets</depend>
   <depend>libogre-dev</depend>
-  <depend>roscpp</depend>
-  <depend>rviz2</depend>
+  <depend>rclcpp</depend>
+  <depend>rviz_common</depend>
+  <depend>rviz_rendering</depend>
+  <depend>rviz_default_plugins</depend>
+  <depend>std_srvs</depend>
   <depend>flatland_server</depend>
-  <depend>flatland_msgs</depend>  
+  <depend>flatland_msgs</depend>
+  <depend>visualization_msgs</depend>
+  <depend>interactive_markers</depend>
+  <depend>libboost-date-time-dev</depend>
+  <depend>libboost-filesystem-dev</depend>
+  <depend>libboost-dev</depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
 
   <export>
+    <build_type>ament_cmake</build_type>
+    
     <!-- Other tools can request additional information be placed here -->
       <rviz plugin="${prefix}/plugin_description.xml"/>
       <flatland_viz plugin="${prefix}/plugin_description.xml"/>

--- a/flatland_viz/plugin_description.xml
+++ b/flatland_viz/plugin_description.xml
@@ -1,14 +1,14 @@
 <library path="lib/libflatland_viz_plugins">
   <class name="flatland_viz/SpawnModel"
          type="flatland_viz::SpawnModelTool"
-         base_class_type="rviz::Tool">
+         base_class_type="rviz_common::Tool">
     <description>
       Tool for spwaning models on the ground plane in flatland.
     </description>
   </class>
   <class name="flatland_viz/PauseSim"
          type="flatland_viz::PauseSimTool"
-         base_class_type="rviz::Tool">
+         base_class_type="rviz_common::Tool">
     <description>
       Tool for pausing and unpausing flatland simulation.
     </description>

--- a/flatland_viz/src/flatland_viz.cpp
+++ b/flatland_viz/src/flatland_viz.cpp
@@ -70,11 +70,6 @@
 #include <rclcpp/rclcpp.hpp>
 #include <stdlib.h>
 
-#include "rviz/display.h"
-#include "rviz/render_panel.h"
-#include "rviz/view_manager.h"
-#include "rviz/visualization_manager.h"
-
 #include "flatland_viz/flatland_window.h"
 
 #include "flatland_viz/flatland_viz.h"
@@ -90,7 +85,7 @@ FlatlandViz::FlatlandViz(FlatlandWindow* parent) : QWidget((QWidget*)parent) {
   initMenus();
 
   // Construct and lay out render panel.
-  render_panel_ = new rviz::RenderPanel();
+  render_panel_ = new rviz_common::RenderPanel();
   QVBoxLayout* main_layout = new QVBoxLayout;
   main_layout->setMargin(0);
   main_layout->addWidget(render_panel_);
@@ -104,21 +99,21 @@ FlatlandViz::FlatlandViz(FlatlandWindow* parent) : QWidget((QWidget*)parent) {
   // holds the main Ogre scene, holds the ViewController, etc.  It is
   // very central and we will probably need one in every usage of
   // librviz.
-  manager_ = new rviz::VisualizationManager(render_panel_);
+  manager_ = new rviz_common::VisualizationManager(render_panel_);
   render_panel_->initialize(manager_->getSceneManager(), manager_);
 
   // bind toolbar events
-  rviz::ToolManager* tool_man = manager_->getToolManager();
+  rviz_common::ToolManager* tool_man = manager_->getToolManager();
 
   connect(manager_, SIGNAL(configChanged()), this,
           SLOT(setDisplayConfigModified()));
-  connect(tool_man, &rviz::ToolManager::toolAdded, this, &FlatlandViz::addTool);
-  connect(tool_man, SIGNAL(toolRemoved(rviz::Tool*)), this,
-          SLOT(removeTool(rviz::Tool*)));
-  connect(tool_man, SIGNAL(toolRefreshed(rviz::Tool*)), this,
-          SLOT(refreshTool(rviz::Tool*)));
-  connect(tool_man, SIGNAL(toolChanged(rviz::Tool*)), this,
-          SLOT(indicateToolIsCurrent(rviz::Tool*)));
+  connect(tool_man, &rviz_common::ToolManager::toolAdded, this, &FlatlandViz::addTool);
+  connect(tool_man, SIGNAL(toolRemoved(rviz_common::Tool*)), this,
+          SLOT(removeTool(rviz_common::Tool*)));
+  connect(tool_man, SIGNAL(toolRefreshed(rviz_common::Tool*)), this,
+          SLOT(refreshTool(rviz_common::Tool*)));
+  connect(tool_man, SIGNAL(toolChanged(rviz_common::Tool*)), this,
+          SLOT(indicateToolIsCurrent(rviz_common::Tool*)));
 
   manager_->initialize();
 
@@ -134,7 +129,7 @@ FlatlandViz::FlatlandViz(FlatlandWindow* parent) : QWidget((QWidget*)parent) {
   // Create a Grid display.
   grid_ = manager_->createDisplay("rviz/Grid", "adjustable grid", true);
   if (grid_ == nullptr) {
-    ROS_FATAL("Grid failed to instantiate");
+    RCLCPP_WARN(rclcpp::get_logger("flatland_viz"), "Grid failed to instantiate");
     exit(1);
   }
 
@@ -149,16 +144,18 @@ FlatlandViz::FlatlandViz(FlatlandWindow* parent) : QWidget((QWidget*)parent) {
   interactive_markers_ =
       manager_->createDisplay("rviz/InteractiveMarkers", "Move Objects", false);
   if (interactive_markers_ == nullptr) {
-    ROS_FATAL("Interactive markers failed to instantiate");
+    RCLCPP_WARN(rclcpp::get_logger("flatland_viz"), "Interactive markers failed to instantiate");
     exit(1);
   }
   interactive_markers_->subProp("Update Topic")
       ->setValue("/interactive_model_markers/update");
 
+  std::shared_ptr<rclcpp::Node> node = rclcpp::Node::make_shared("flatland_viz");
+
   // Subscribe to debug topics topic
-  ros::NodeHandle n;
-  debug_topic_subscriber_ = n.subscribe("/flatland_server/debug/topics", 0,
-                                        &FlatlandViz::RecieveDebugTopics, this);
+  using std::placeholders::_1;
+  debug_topic_subscriber_ = node->create_subscription<flatland_msgs::msg::DebugTopicList>(
+              "/flatland_server/debug/topics", 0, std::bind(&FlatlandViz::RecieveDebugTopics, this, _1));
 }
 
 // Destructor.
@@ -167,7 +164,7 @@ FlatlandViz::~FlatlandViz() {
   delete manager_;
 }
 
-void FlatlandViz::indicateToolIsCurrent(rviz::Tool* tool) {
+void FlatlandViz::indicateToolIsCurrent(rviz_common::Tool* tool) {
   QAction* action = tool_to_action_map_[tool];
   if (action) {
     action->setChecked(true);
@@ -175,11 +172,11 @@ void FlatlandViz::indicateToolIsCurrent(rviz::Tool* tool) {
 }
 
 void FlatlandViz::setDisplayConfigModified() {
-  ROS_ERROR("setDisplayConfigModified called");
+  RCLCPP_ERROR(rclcpp::get_logger("flatland_viz"), "setDisplayConfigModified called");
 }
 
-void FlatlandViz::addTool(rviz::Tool* tool) {
-  ROS_ERROR("addTool called");
+void FlatlandViz::addTool(rviz_common::Tool* tool) {
+  RCLCPP_ERROR(rclcpp::get_logger("flatland_viz"), "addTool called");
   QAction* action = new QAction(tool->getName(), toolbar_actions_);
   action->setIcon(tool->getIcon());
   action->setIconText(tool->getName());
@@ -192,10 +189,10 @@ void FlatlandViz::addTool(rviz::Tool* tool) {
 }
 
 void FlatlandViz::onToolbarActionTriggered(QAction* action) {
-  ROS_ERROR("onToolbarActionTriggered called");
+  RCLCPP_ERROR(rclcpp::get_logger("flatland_viz"), "onToolbarActionTriggered called");
 
-  rviz::Tool* current_tool = manager_->getToolManager()->getCurrentTool();
-  rviz::Tool* tool = action_to_tool_map_[action];
+  rviz_common::Tool* current_tool = manager_->getToolManager()->getCurrentTool();
+  rviz_common::Tool* tool = action_to_tool_map_[action];
 
   if (tool) {
     manager_->getToolManager()->setCurrentTool(tool);
@@ -218,8 +215,8 @@ void FlatlandViz::onToolbarActionTriggered(QAction* action) {
   }
 }
 
-void FlatlandViz::removeTool(rviz::Tool* tool) {
-  ROS_ERROR("removeTool called");
+void FlatlandViz::removeTool(rviz_common::Tool* tool) {
+  RCLCPP_ERROR(rclcpp::get_logger("flatland_viz"), "removeTool called");
   QAction* action = tool_to_action_map_[tool];
   if (action) {
     toolbar_actions_->removeAction(action);
@@ -230,7 +227,7 @@ void FlatlandViz::removeTool(rviz::Tool* tool) {
   QString tool_name = tool->getName();
   QList<QAction*> remove_tool_actions = remove_tool_menu_->actions();
   for (int i = 0; i < remove_tool_actions.size(); i++) {
-    ROS_ERROR_STREAM("Removing --------> " << tool_name.toStdString());
+    RCLCPP_ERROR_STREAM(rclcpp::get_logger("flatland_viz"), "Removing --------> " << tool_name.toStdString());
     QAction* removal_action = remove_tool_actions.at(i);
     if (removal_action->text() == tool_name) {
       remove_tool_menu_->removeAction(removal_action);
@@ -303,7 +300,7 @@ void FlatlandViz::initToolbars() {
 
   add_tool_action_ = new QAction("", toolbar_actions_);
   add_tool_action_->setToolTip("Add a new tool");
-  add_tool_action_->setIcon(rviz::loadPixmap("package://rviz/icons/plus.png"));
+  add_tool_action_->setIcon(rviz_common::loadPixmap("package://rviz_common/icons/plus.png"));
   toolbar_->addAction(add_tool_action_);
 
   connect(add_tool_action_, &QAction::triggered, this,
@@ -315,7 +312,7 @@ void FlatlandViz::initToolbars() {
   remove_tool_button->setPopupMode(QToolButton::InstantPopup);
   remove_tool_button->setToolTip("Remove a tool from the toolbar");
   remove_tool_button->setIcon(
-      rviz::loadPixmap("package://rviz/icons/minus.png"));
+      rviz_common::loadPixmap("package://rviz_common/icons/minus.png"));
   toolbar_->addWidget(remove_tool_button);
 
   connect(remove_tool_menu_, &QMenu::triggered, this,
@@ -323,13 +320,13 @@ void FlatlandViz::initToolbars() {
 }
 
 void FlatlandViz::openNewToolDialog() {
-  ROS_ERROR("openNewToolDialog called");
+  RCLCPP_ERROR(rclcpp::get_logger("flatland_viz"), "openNewToolDialog called");
   QString class_id;
   QStringList empty;
-  rviz::ToolManager* tool_man = manager_->getToolManager();
+  rviz_common::ToolManager* tool_man = manager_->getToolManager();
 
-  rviz::NewObjectDialog* dialog =
-      new rviz::NewObjectDialog(tool_man->getFactory(), "Tool", empty,
+  rviz_common::NewObjectDialog* dialog =
+      new rviz_common::NewObjectDialog(tool_man->getFactory(), "Tool", empty,
                                 tool_man->getToolClasses(), &class_id);
   manager_->stopUpdate();
   if (dialog->exec() == QDialog::Accepted) {
@@ -340,12 +337,13 @@ void FlatlandViz::openNewToolDialog() {
 }
 
 void FlatlandViz::onToolbarRemoveTool(QAction* remove_tool_menu_action) {
-  ROS_ERROR("onToolbarRemoveTool called");
+  RCLCPP_ERROR(rclcpp::get_logger("flatland_viz"), "onToolbarRemoveTool called");
   QString name = remove_tool_menu_action->text();
+
   for (int i = 0; i < manager_->getToolManager()->numTools(); i++) {
-    rviz::Tool* tool = manager_->getToolManager()->getTool(i);
+    rviz_common::Tool* tool = manager_->getToolManager()->getTool(i);
     if (tool->getName() == name) {
-      ROS_ERROR_STREAM("Removing --------> " << name.toStdString());
+      RCLCPP_ERROR_(rclcpp::get_logger("flatland_viz"), _STREAM("Removing --------> " << name.toStdString());
       manager_->getToolManager()->removeTool(i);
       removeTool(tool);
       return;
@@ -353,7 +351,7 @@ void FlatlandViz::onToolbarRemoveTool(QAction* remove_tool_menu_action) {
   }
 }
 
-void FlatlandViz::refreshTool(rviz::Tool* tool) {
+void FlatlandViz::refreshTool(rviz_common::Tool* tool) {
   QAction* action = tool_to_action_map_[tool];
   action->setIcon(tool->getIcon());
   action->setIconText(tool->getName());
@@ -374,8 +372,8 @@ void FlatlandViz::setFullScreen(bool full_screen) {
   show();
 }
 
-void FlatlandViz::RecieveDebugTopics(const flatland_msgs::msg::DebugTopicList& msg) {
-  std::vector<std::string> topics = msg.topics;
+void FlatlandViz::RecieveDebugTopics(const flatland_msgs::msg::DebugTopicList::SharedPtr msg) {
+  std::vector<std::string> topics = msg->topics;
 
   // check for deleted topics
   for (auto& topic : debug_displays_) {
@@ -392,7 +390,7 @@ void FlatlandViz::RecieveDebugTopics(const flatland_msgs::msg::DebugTopicList& m
       debug_displays_[topic] = manager_->createDisplay(
           "rviz/MarkerArray", QString::fromLocal8Bit(topic.c_str()), true);
       if (debug_displays_[topic] == nullptr) {
-        ROS_FATAL("MarkerArray failed to instantiate");
+        RCLCPP_WARN(rclcpp::get_logger("flatland_viz"), "MarkerArray failed to instantiate");
         exit(1);
       }
       QString topic_qt = QString::fromLocal8Bit(

--- a/flatland_viz/src/flatland_viz_node.cpp
+++ b/flatland_viz/src/flatland_viz_node.cpp
@@ -57,18 +57,18 @@ FlatlandWindow* window = nullptr;
  * @param[in]   sig: signal itself
  */
 void SigintHandler(int sig) {
-  RCLCPP_WARN(rclcpp::get_logger("Node", "*** Shutting down... ***"));
+  RCLCPP_WARN(rclcpp::get_logger("Node"), "*** Shutting down... ***");
 
   if (window != nullptr) {
     delete window;
     window = nullptr;
   }
   RCLCPP_INFO_STREAM(rclcpp::get_logger("Flatland Viz"), "Beginning ros shutdown");
-  ros::shutdown();
+  rclcpp::shutdown();
 }
 
 int main(int argc, char** argv) {
-  if (!ros::isInitialized()) {
+  if (!rclcpp::isInitialized()) {
     rclcpp::init(argc, argv);
   }
 

--- a/flatland_viz/src/flatland_window.cpp
+++ b/flatland_viz/src/flatland_window.cpp
@@ -47,58 +47,12 @@
 
 #include "flatland_viz/flatland_window.h"
 
-#include <QAction>
-#include <QActionGroup>
-#include <QDesktopWidget>
-#include <QFileDialog>
-#include <QHBoxLayout>
-#include <QLabel>
-#include <QMessageBox>
-#include <QStatusBar>
-#include <QToolBar>
-#include <QToolButton>
-#include <QVBoxLayout>
-#include <QWidget>
-
-#include "rviz/display.h"
-#include "rviz/display_context.h"
-#include "rviz/displays_panel.h"
-#include "rviz/env_config.h"
-#include "rviz/failed_panel.h"
-#include "rviz/help_panel.h"
-#include "rviz/load_resource.h"
-#include "rviz/loading_dialog.h"
-#include "rviz/new_object_dialog.h"
-#include "rviz/panel_dock_widget.h"
-#include "rviz/panel_factory.h"
-#include "rviz/properties/status_property.h"
-#include "rviz/render_panel.h"
-#include "rviz/screenshot_dialog.h"
-#include "rviz/selection/selection_manager.h"
-#include "rviz/selection_panel.h"
-#include "rviz/splash_screen.h"
-#include "rviz/time_panel.h"
-#include "rviz/tool.h"
-#include "rviz/tool_manager.h"
-#include "rviz/tool_properties_panel.h"
-#include "rviz/view_manager.h"
-#include "rviz/views_panel.h"
-#include "rviz/visualization_frame.h"
-#include "rviz/visualization_manager.h"
-#include "rviz/widget_geometry_change_detector.h"
-#include "rviz/yaml_config_reader.h"
-#include "rviz/yaml_config_writer.h"
-
-#include <OgreMeshManager.h>
-#include <OgreRenderWindow.h>
-//#include <ogre_helpers/initialization.h>
-
 void FlatlandWindow::openNewToolDialog() {
   QString class_id;
   QStringList empty;
 }
 
-rviz::VisualizationManager *FlatlandWindow::getManager() {
+rviz_common::VisualizationManager *FlatlandWindow::getManager() {
   return visualization_manager_;
 }
 

--- a/flatland_viz/src/load_model_dialog.cpp
+++ b/flatland_viz/src/load_model_dialog.cpp
@@ -45,19 +45,23 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "flatland_viz/load_model_dialog.h"
+
 #include <OGRE/OgreEntity.h>
 #include <OGRE/OgreSceneManager.h>
 #include <OGRE/OgreSceneNode.h>
-#include <OgreVector3.h>
+#include <OGRE/OgreVector3.h>
+//#include <OgreVector3.h>
 
-#include <ros/console.h>
+#include <rclcpp/rclcpp.hpp>
 
-#include <rviz/geometry.h>
-#include <rviz/mesh_loader.h>
-#include <rviz/properties/float_property.h>
-#include <rviz/properties/vector_property.h>
-#include <rviz/viewport_mouse_event.h>
-#include <rviz/visualization_manager.h>
+#include <rviz_rendering/geometry.hpp>
+#include <rviz_rendering/mesh_loader.hpp>
+
+#include <rviz_common/properties/float_property.hpp>
+#include <rviz_common/properties/vector_property.hpp>
+#include <rviz_common/viewport_mouse_event.hpp>
+#include <rviz_common/visualization_manager.h>
 
 #include <QCheckBox>
 #include <QCursor>
@@ -72,10 +76,7 @@
 
 #include <boost/filesystem.hpp>
 
-#include "flatland_viz/load_model_dialog.h"
 #include "flatland_viz/spawn_model_tool.h"
-// #include "load_model_dialog.h"
-// #include "spawn_model_tool.h"
 
 QString LoadModelDialog::path_to_model_file;
 int LoadModelDialog::count;
@@ -177,6 +178,7 @@ void LoadModelDialog::AddNumberAndUpdateName() {
   std::string bsfn =
       boost::filesystem::basename(path_to_model_file.toStdString());
   QString name = QString::fromStdString(bsfn);
+
 
   if (numbering) {
     name = name.append(QString::number(count++));

--- a/flatland_viz/src/model_dialog.cpp
+++ b/flatland_viz/src/model_dialog.cpp
@@ -78,7 +78,7 @@ QString ModelDialog::SelectFile() {
 }
 
 ModelDialog::ModelDialog(QWidget *parent) : QDialog(parent) {
-  ROS_ERROR_STREAM("ModelDialog::ModelDialog");
+  RCLCPP_ERROR(rclcpp::get_logger("flatland_viz"), "ModelDialog::ModelDialog");
 
   path_to_model_file = SelectFile();
   QVBoxLayout *v_layout = new QVBoxLayout;
@@ -125,11 +125,11 @@ ModelDialog::ModelDialog(QWidget *parent) : QDialog(parent) {
   static bool first_time = true;
   QColor color;
   if (first_time) {
-    ROS_ERROR_STREAM("firstTime");
+    RCLCPP_ERROR(rclcpp::get_logger("flatland_viz"), "firstTime");
     first_time = false;
     color = Qt::blue;
   } else {
-    ROS_ERROR_STREAM("anotherTime");
+    RCLCPP_ERROR(rclcpp::get_logger("flatland_viz"), "anotherTime");
     color = saved_color_;
   }
 
@@ -175,13 +175,13 @@ ModelDialog::ModelDialog(QWidget *parent) : QDialog(parent) {
 }
 
 void ModelDialog::CancelButtonClicked() {
-  ROS_ERROR_STREAM("Cancel clicked");
+  RCLCPP_ERROR(rclcpp::get_logger("flatland_viz"), "Cancel clicked");
   this->close();
 }
 
 void ModelDialog::OkButtonClicked() {
-  ROS_ERROR_STREAM("Ok clicked");
-  ROS_ERROR_STREAM("connect to ROS model service");
+  RCLCPP_ERROR(rclcpp::get_logger("flatland_viz"), "Ok clicked");
+  RCLCPP_ERROR(rclcpp::get_logger("flatland_viz"), "connect to ROS model service");
 
   ModelDialog::SpawnModelClient();
 }

--- a/flatland_viz/src/pause_sim_tool.cpp
+++ b/flatland_viz/src/pause_sim_tool.cpp
@@ -5,19 +5,20 @@ namespace flatland_viz {
 PauseSimTool::PauseSimTool() {}
 
 // Disconnect the service client when the tool's destructor is called
-PauseSimTool::~PauseSimTool() { pause_service_.shutdown(); }
+PauseSimTool::~PauseSimTool() { rclcpp::shutdown(); /*pause_service_->shutdown();*/ }
 
 // When the tool is initially loaded, connect to the pause toggle service
 void PauseSimTool::onInitialize() {
-  pause_service_ = nh_.serviceClient<std_srvs::Empty>("toggle_pause");
-  setName("Pause/Resume");
+    std::shared_ptr<rclcpp::Node> node = rclcpp::Node::make_shared("pause_sim_tool");  // TODO
+    pause_service_ = node->create_client<std_srvs::srv::Empty>("toggle_pause");
+    setName("Pause/Resume");
 }
 
 // Every time the user presses the tool's Rviz toolbar button, call the pause
 // toggle service
 void PauseSimTool::activate() {
-  std_srvs::Empty empty;
-  pause_service_.call(empty);
+    auto request = std::make_shared<std_srvs::srv::Empty::Request>();
+    auto result = pause_service_->async_send_request(request);
 }
 
 void PauseSimTool::deactivate() {}
@@ -26,4 +27,4 @@ void PauseSimTool::deactivate() {}
 
 // Tell pluginlib about the tool class
 #include <pluginlib/class_list_macros.hpp>
-PLUGINLIB_EXPORT_CLASS(flatland_viz::PauseSimTool, rviz::Tool)
+PLUGINLIB_EXPORT_CLASS(flatland_viz::PauseSimTool, rviz_common::Tool)


### PR DESCRIPTION
This pull request provides some fixes and updates for flatland_server and flatland_plugins.
- Fixed segmentation fault in tricycle and diff drive plugin (plugins seem to work but there might be still problems)
- Added missing dependencies
- Updated deprecated commands in CMakeLists.txt and code for ros2 foxy

I tried to port flatland_viz but there is still a lot to do. The biggest problem is that many included header files are not publicly available in rviz2. I'm not sure how to deal with this problem yet.

Tested on Ubuntu 20.04 with ROS2 foxy.