### PR TITLE
Made dynamics limits a generic class, improved its function in TricycleDrive plugin

### DIFF
--- a/docs/included_plugins/diff_drive.rst
+++ b/docs/included_plugins/diff_drive.rst
@@ -92,3 +92,17 @@ velocities and odometries are w.r.t. the robot origin
                              0, 0, 0, 0, 0, 0
                              0, 0, 0, 0, 0, 0
                              0, 0, 0, 0, 0, 0]
+
+      # optional, defaults each parameter to 0.0 which means "no limit"
+      # sets dynamics constraints on angular velocity, acceleration (in rads/sec; rads/sec/sec)
+      angular_dynamics:
+        acceleration_limit: 0.0   # max acceleration (away from 0), in rads/s/s; 0.0 means "no limit"
+        deceleration_limit: 0.0  # max deceleration (towards 0), in rads/s/s; 0.0 means "no limit"; left blank, will default to acceleration_limit value
+        velocity_limit: 0.0       # max absolute velocity in rads/s; 0.0 means "no limit"
+
+      # optional, defaults each parameter to 0.0 which means "no limit"
+      # sets dynamics constraints on linear velocity, acceleration (in m/s; m/s/s)
+      linear_dynamics:
+        acceleration_limit: 0.0   # max acceleration (away from 0), in m/s/s; 0.0 means "no limit"
+        deceleration_limit: 0.0  # max deceleration (towards 0), in m/s/s; 0.0 means "no limit"; left blank, will default to acceleration_limit value
+        velocity_limit: 0.0       # max absolute velocity in m/s; 0.0 means "no limit"

--- a/docs/included_plugins/diff_drive.rst
+++ b/docs/included_plugins/diff_drive.rst
@@ -97,12 +97,12 @@ velocities and odometries are w.r.t. the robot origin
       # sets dynamics constraints on angular velocity, acceleration (in rads/sec; rads/sec/sec)
       angular_dynamics:
         acceleration_limit: 0.0   # max acceleration (away from 0), in rads/s/s; 0.0 means "no limit"
-        deceleration_limit: 0.0  # max deceleration (towards 0), in rads/s/s; 0.0 means "no limit"; left blank, will default to acceleration_limit value
+        deceleration_limit: 0.0   # max deceleration (towards 0), in rads/s/s; 0.0 means "no limit"; left blank, will default to acceleration_limit value
         velocity_limit: 0.0       # max absolute velocity in rads/s; 0.0 means "no limit"
 
       # optional, defaults each parameter to 0.0 which means "no limit"
       # sets dynamics constraints on linear velocity, acceleration (in m/s; m/s/s)
       linear_dynamics:
         acceleration_limit: 0.0   # max acceleration (away from 0), in m/s/s; 0.0 means "no limit"
-        deceleration_limit: 0.0  # max deceleration (towards 0), in m/s/s; 0.0 means "no limit"; left blank, will default to acceleration_limit value
+        deceleration_limit: 0.0   # max deceleration (towards 0), in m/s/s; 0.0 means "no limit"; left blank, will default to acceleration_limit value
         velocity_limit: 0.0       # max absolute velocity in m/s; 0.0 means "no limit"

--- a/docs/included_plugins/tricycle_drive.rst
+++ b/docs/included_plugins/tricycle_drive.rst
@@ -122,11 +122,28 @@ has no effect on the actual motion of the robot.
       # the steering angle will not exceed this absolute limit
       max_steer_angle: 0.0
 
+      # optional, defaults each parameter to 0.0 which means "no limit"
+      # sets dynamics constraints on angular velocity, acceleration (in rads/sec; rads/sec/sec)
+      angular_dynamics:
+        acceleration_limit: 0.0   # max acceleration (away from 0), in rads/s/s; 0.0 means "no limit"
+        deceleration_limit: 0.0  # max deceleration (towards 0), in rads/s/s; 0.0 means "no limit"; left blank, will default to acceleration_limit value
+        velocity_limit: 0.0       # max absolute velocity in rads/s; 0.0 means "no limit"
+
+      # optional, defaults each parameter to 0.0 which means "no limit"
+      # sets dynamics constraints on linear velocity, acceleration (in m/s; m/s/s)
+      linear_dynamics:
+        acceleration_limit: 0.0   # max acceleration (away from 0), in m/s/s; 0.0 means "no limit"
+        deceleration_limit: 0.0  # max deceleration (towards 0), in m/s/s; 0.0 means "no limit"; left blank, will default to acceleration_limit value
+        velocity_limit: 0.0       # max absolute velocity in m/s; 0.0 means "no limit"
+        
+
+      # DEPRECATED; Use angular_dynamics.velocity_limit instead
       # optional, defaults to 0.0 which means no limit
       # sets the steering angular velocity limit (absolute, rad/s)
       # the steering angular velocity will not exceed this absolute limit
       max_angular_velocity: 0.0
 
+      # DEPRECATED; Use angular_dynamics.acceleration_limit instead
       # optional, defaults to 0.0 which means no limit
       # sets the steering angular acceleration limit (absolute, rad/s^2)
       # the steering angular acceleration will not exceed this absolute limit

--- a/docs/included_plugins/tricycle_drive.rst
+++ b/docs/included_plugins/tricycle_drive.rst
@@ -126,14 +126,14 @@ has no effect on the actual motion of the robot.
       # sets dynamics constraints on angular velocity, acceleration (in rads/sec; rads/sec/sec)
       angular_dynamics:
         acceleration_limit: 0.0   # max acceleration (away from 0), in rads/s/s; 0.0 means "no limit"
-        deceleration_limit: 0.0  # max deceleration (towards 0), in rads/s/s; 0.0 means "no limit"; left blank, will default to acceleration_limit value
+        deceleration_limit: 0.0   # max deceleration (towards 0), in rads/s/s; 0.0 means "no limit"; left blank, will default to acceleration_limit value
         velocity_limit: 0.0       # max absolute velocity in rads/s; 0.0 means "no limit"
 
       # optional, defaults each parameter to 0.0 which means "no limit"
       # sets dynamics constraints on linear velocity, acceleration (in m/s; m/s/s)
       linear_dynamics:
         acceleration_limit: 0.0   # max acceleration (away from 0), in m/s/s; 0.0 means "no limit"
-        deceleration_limit: 0.0  # max deceleration (towards 0), in m/s/s; 0.0 means "no limit"; left blank, will default to acceleration_limit value
+        deceleration_limit: 0.0   # max deceleration (towards 0), in m/s/s; 0.0 means "no limit"; left blank, will default to acceleration_limit value
         velocity_limit: 0.0       # max absolute velocity in m/s; 0.0 means "no limit"
         
 

--- a/flatland_plugins/CMakeLists.txt
+++ b/flatland_plugins/CMakeLists.txt
@@ -72,6 +72,7 @@ add_library(flatland_plugins_lib
   src/laser.cpp
   src/tricycle_drive.cpp
   src/diff_drive.cpp
+  src/dynamics_limits.cpp
   src/model_tf_publisher.cpp
   src/update_timer.cpp
   src/bumper.cpp
@@ -139,6 +140,9 @@ if(CATKIN_ENABLE_TESTING)
   add_rostest_gtest(laser_test test/laser_test.test
                     test/laser_test.cpp)
   target_link_libraries(laser_test flatland_plugins_lib)
+
+  catkin_add_gtest(dynamics_limits_test test/dynamics_limits_test.cpp)
+  target_link_libraries(dynamics_limits_test flatland_plugins_lib)
 
   add_rostest_gtest(tricycle_drive_test test/tricycle_drive_test.test
                     test/tricycle_drive_test.cpp)

--- a/flatland_plugins/include/flatland_plugins/diff_drive.h
+++ b/flatland_plugins/include/flatland_plugins/diff_drive.h
@@ -46,6 +46,7 @@
 
 #include <Box2D/Box2D.h>
 #include <flatland_plugins/update_timer.h>
+#include <flatland_plugins/dynamics_limits.h>
 #include <flatland_server/model_plugin.h>
 #include <flatland_server/timekeeper.h>
 #include <geometry_msgs/Twist.h>
@@ -74,6 +75,10 @@ class DiffDrive : public flatland_server::ModelPlugin {
   tf::TransformBroadcaster tf_broadcaster;  ///< For publish ROS TF
   bool enable_odom_pub_;   ///< YAML parameter to enable odom publishing
   bool enable_twist_pub_;  ///< YAML parameter to enable twist publishing
+  DynamicsLimits angular_dynamics_; ///< Angular dynamics constraints
+  DynamicsLimits linear_dynamics_;  ///< Linear dynamics constraints
+  double angular_velocity_ = 0.0;
+  double linear_velocity_ = 0.0;
 
   std::default_random_engine rng_;
   std::array<std::normal_distribution<double>, 6> noise_gen_;

--- a/flatland_plugins/include/flatland_plugins/dynamics_limits.h
+++ b/flatland_plugins/include/flatland_plugins/dynamics_limits.h
@@ -1,0 +1,100 @@
+/*
+ *  ______                   __  __              __
+ * /\  _  \           __    /\ \/\ \            /\ \__
+ * \ \ \L\ \  __  __ /\_\   \_\ \ \ \____    ___\ \ ,_\   ____
+ *  \ \  __ \/\ \/\ \\/\ \  /'_` \ \ '__`\  / __`\ \ \/  /',__\
+ *   \ \ \/\ \ \ \_/ |\ \ \/\ \L\ \ \ \L\ \/\ \L\ \ \ \_/\__, `\
+ *    \ \_\ \_\ \___/  \ \_\ \___,_\ \_,__/\ \____/\ \__\/\____/
+ *     \/_/\/_/\/__/    \/_/\/__,_ /\/___/  \/___/  \/__/\/___/
+ * @copyright Copyright 2021 Avidbots Corp.
+ * @name	DYNAMICS_LIMITS.h
+ * @brief   A generic acceleration, deceleration and velocity bounding utility class
+ * @author  Joseph Duchesne
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Avidbots Corp.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Avidbots Corp. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#ifndef FLATLAND_PLUGINS_DYNAMICS_LIMITS_H
+#define FLATLAND_PLUGINS_DYNAMICS_LIMITS_H
+
+#include <flatland_server/yaml_reader.h>
+#include <yaml-cpp/yaml.h>
+
+namespace flatland_plugins {
+
+/**
+ * This class implements the model plugin class and provides laser data
+ * for the given configurations
+ */
+class DynamicsLimits {
+ public:
+  double acceleration_limit_ = 0.0;  // Maximum rate of change in velocity in the direction away from zero. Zero value disables this limit.
+  double deceleration_limit_ = 0.0; // Maximum rate of change in velocity in the direction towards zero. Zero value disables this limit.
+  double velocity_limit_ = 0.0;      // Maximum rate of change in position (in either direction). Zero value disables this limit.
+
+
+  /**
+   * @brief               blank constructor, no-op class
+   */
+  DynamicsLimits() {};
+
+  /**
+   * @name         Load configuration from a yaml object
+   * @brief        Constructor from yaml configuration file node
+   * @param[in]    YAML::Node& configuration node
+   */
+   void Configure(const YAML::Node &config);
+
+  /**
+   * @name          Saturate
+   * @brief         Apply dynamics limits
+   * @param[in]     config The plugin YAML node
+   */
+   double Saturate(double in, double lower, double upper);
+
+  /**
+   * @name          Apply
+   * @brief         Apply dynamics limits based on class configured limits
+   * @param[in]     velocity The current velocity (units/second)
+   * @param[in]     target_velocity The target velocity requested (units/second)
+   * @param[in]     timestep  The timestep (seconds) (used to calculate acceleration from delta velocity)
+   * @return        The new velocity result after target velocity has been subjected to limits
+   */
+   double Limit(double velocity, double target_velocity, double timestep);
+
+};
+
+};
+
+#endif  // FLATLAND_PLUGINS_DYNAMICS_LIMITS_H

--- a/flatland_plugins/include/flatland_plugins/dynamics_limits.h
+++ b/flatland_plugins/include/flatland_plugins/dynamics_limits.h
@@ -7,7 +7,7 @@
  *    \ \_\ \_\ \___/  \ \_\ \___,_\ \_,__/\ \____/\ \__\/\____/
  *     \/_/\/_/\/__/    \/_/\/__,_ /\/___/  \/___/  \/__/\/___/
  * @copyright Copyright 2021 Avidbots Corp.
- * @name	DYNAMICS_LIMITS.h
+ * @name	Dynamics_Limits.h
  * @brief   A generic acceleration, deceleration and velocity bounding utility class
  * @author  Joseph Duchesne
  *
@@ -81,7 +81,7 @@ class DynamicsLimits {
    * @brief         Apply dynamics limits
    * @param[in]     config The plugin YAML node
    */
-   double Saturate(double in, double lower, double upper);
+   static double Saturate(double in, double lower, double upper);
 
   /**
    * @name          Apply

--- a/flatland_plugins/include/flatland_plugins/tricycle_drive.h
+++ b/flatland_plugins/include/flatland_plugins/tricycle_drive.h
@@ -46,6 +46,7 @@
 
 #include <Box2D/Box2D.h>
 #include <flatland_plugins/update_timer.h>
+#include <flatland_plugins/dynamics_limits.h>
 #include <flatland_server/model_plugin.h>
 #include <flatland_server/timekeeper.h>
 #include <geometry_msgs/Twist.h>
@@ -73,9 +74,12 @@ class TricycleDrive : public flatland_server::ModelPlugin {
   double max_steer_angle_;         ///< max abs. steering allowed [rad]
   double max_steer_velocity_;      ///< max abs. steering velocity [rad/s]
   double max_steer_acceleration_;  ///< max abs. steering acceleration [rad/s^2]
+  DynamicsLimits angular_dynamics_; ///< Angular dynamics constraints
+  DynamicsLimits linear_dynamics_;  ///< Linear dynamics constraints
   double delta_command_;  ///< The current target (commanded) wheel angle
   double theta_f_;        ///< The current angular offset of the front wheel
   double d_delta_;        ///< The current angular speed of the front wheel
+  double v_f_ = 0.0;      ///< The current velocity at the front wheel
 
   geometry_msgs::Twist twist_msg_;
   nav_msgs::Odometry odom_msg_;

--- a/flatland_plugins/src/dynamics_limits.cpp
+++ b/flatland_plugins/src/dynamics_limits.cpp
@@ -1,0 +1,107 @@
+/*
+ *  ______                   __  __              __
+ * /\  _  \           __    /\ \/\ \            /\ \__
+ * \ \ \L\ \  __  __ /\_\   \_\ \ \ \____    ___\ \ ,_\   ____
+ *  \ \  __ \/\ \/\ \\/\ \  /'_` \ \ '__`\  / __`\ \ \/  /',__\
+ *   \ \ \/\ \ \ \_/ |\ \ \/\ \L\ \ \ \L\ \/\ \L\ \ \ \_/\__, `\
+ *    \ \_\ \_\ \___/  \ \_\ \___,_\ \_,__/\ \____/\ \__\/\____/
+ *     \/_/\/_/\/__/    \/_/\/__,_ /\/___/  \/___/  \/__/\/___/
+ * @copyright Copyright 2021 Avidbots Corp.
+ * @name	dynamics_limits.cpp
+ * @brief   A generic acceleration, deceleration and velocity bounding utility class
+ * @author  Joseph Duchesne
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Avidbots Corp.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Avidbots Corp. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "flatland_plugins/dynamics_limits.h"
+
+namespace flatland_plugins {
+
+void DynamicsLimits::Configure(const YAML::Node &config) {
+  flatland_server::YamlReader reader(config);
+  acceleration_limit_ = reader.Get<double>("acceleration_limit", 0.0);  // 0.0 default disables the limit
+  deceleration_limit_ = reader.Get<double>("deceleration_limit", std::numeric_limits<double>::infinity());
+
+  // if no acceleration limit is set, default it to equal the acceleration limit
+  if (deceleration_limit_ == std::numeric_limits<double>::infinity()) {
+    deceleration_limit_ = acceleration_limit_;
+  }
+
+  velocity_limit_ = reader.Get<double>("velocity_limit", 0.0);   // 0.0 default disables the limit
+}
+
+double DynamicsLimits::Saturate(double in, double lower, double upper) {
+  if (lower > upper) {
+    return in;
+  }
+  double out = in;
+  out = std::max(out, lower);
+  out = std::min(out, upper);
+  return out;
+}
+
+double DynamicsLimits::Limit(double velocity, double target_velocity, double timestep) {
+
+  // if enabled, apply velocity limit
+  if (velocity_limit_ != 0.0) {
+    // Saturating the command also saturates the steering velocity
+    target_velocity = Saturate(target_velocity, -velocity_limit_, velocity_limit_);
+  }
+
+  // if the target velocity magnitude is larger, and in the same direction, we're accelerating
+  double acceleration_limit;
+  if (target_velocity == 0) {  // we can only be decellerating
+    acceleration_limit = deceleration_limit_;
+  } else if (velocity == 0) {  // we can only be accelerating
+    acceleration_limit = acceleration_limit_;
+  } else if (velocity*target_velocity < 0) {  // velocities are in different directions, we must be decelerating
+    acceleration_limit = deceleration_limit_;
+  } else if (fabs(velocity) < fabs(target_velocity))  {  // new velocity magnitude is larger than old, and in the same direction: accelerating
+    acceleration_limit = acceleration_limit_;
+  } else {  // new velocity magnitude is smaller than old, in the same direction: decellerating
+    acceleration_limit = deceleration_limit_;
+  }
+
+  // compute accleration, and limit it if needed
+  double acceleration = (target_velocity - velocity) / timestep;
+  if (acceleration_limit != 0.0) {
+    acceleration =
+        Saturate(acceleration, -acceleration_limit, acceleration_limit);
+  }
+
+  // (2) Update the new steering velocity
+  return velocity + acceleration * timestep;
+}
+
+}  /* end namespace flatland_plugins */

--- a/flatland_plugins/src/dynamics_limits.cpp
+++ b/flatland_plugins/src/dynamics_limits.cpp
@@ -76,7 +76,7 @@ double DynamicsLimits::Limit(double velocity, double target_velocity, double tim
   // if enabled, apply velocity limit
   if (velocity_limit_ != 0.0) {
     // Saturating the command also saturates the steering velocity
-    target_velocity = Saturate(target_velocity, -velocity_limit_, velocity_limit_);
+    target_velocity = DynamicsLimits::Saturate(target_velocity, -velocity_limit_, velocity_limit_);
   }
 
   // if the target velocity magnitude is larger, and in the same direction, we're accelerating
@@ -97,7 +97,7 @@ double DynamicsLimits::Limit(double velocity, double target_velocity, double tim
   double acceleration = (target_velocity - velocity) / timestep;
   if (acceleration_limit != 0.0) {
     acceleration =
-        Saturate(acceleration, -acceleration_limit, acceleration_limit);
+        DynamicsLimits::Saturate(acceleration, -acceleration_limit, acceleration_limit);
   }
 
   // (2) Update the new steering velocity

--- a/flatland_plugins/src/tricycle_drive.cpp
+++ b/flatland_plugins/src/tricycle_drive.cpp
@@ -386,7 +386,7 @@ void TricycleDrive::BeforePhysicsStep(const Timekeeper& timekeeper) {
   // (1) Update the new steering angle
   theta_f_ += d_delta_ * dt;
   if (max_steer_angle_ != 0.0) {
-    theta_f_ = Saturate(theta_f_, -max_steer_angle_, max_steer_angle_);
+    theta_f_ = DynamicsLimits::Saturate(theta_f_, -max_steer_angle_, max_steer_angle_);
   }
 
   ROS_DEBUG_THROTTLE(0.5,
@@ -441,15 +441,6 @@ void TricycleDrive::TwistCallback(const geometry_msgs::Twist& msg) {
   twist_msg_ = msg;
 }
 
-double TricycleDrive::Saturate(double in, double lower, double upper) {
-  if (lower > upper) {
-    return in;
-  }
-  double out = in;
-  out = std::max(out, lower);
-  out = std::min(out, upper);
-  return out;
-}
 }
 
 PLUGINLIB_EXPORT_CLASS(flatland_plugins::TricycleDrive,

--- a/flatland_plugins/src/tricycle_drive.cpp
+++ b/flatland_plugins/src/tricycle_drive.cpp
@@ -98,11 +98,22 @@ void TricycleDrive::OnInitialize(const YAML::Node& config) {
   auto odom_pose_covar =
       r.GetArray<double, 36>("odom_pose_covariance", odom_pose_covar_default);
 
-  // Default max_steer_angle=0, max_angular_velocity=0, and
-  // max_steer_acceleration=0 mean "unbounded"
+  // Default max_steer_angle=0.0 means "unbounded"
   max_steer_angle_ = r.Get<double>("max_steer_angle", 0.0);
-  max_steer_velocity_ = r.Get<double>("max_angular_velocity", 0.0);
-  max_steer_acceleration_ = r.Get<double>("max_steer_acceleration", 0.0);
+
+  // Angular dynamics constraints
+  angular_dynamics_.Configure(r.SubnodeOpt("angular_dynamics", YamlReader::MAP).Node());
+
+  // Accept old configuration location for angular dynamics constraints if present
+  if (angular_dynamics_.velocity_limit_ != 0.0) angular_dynamics_.velocity_limit_ = r.Get<double>("max_angular_velocity", 0.0);
+  if (angular_dynamics_.acceleration_limit_ != 0.0) {
+    angular_dynamics_.acceleration_limit_ = r.Get<double>("max_steer_acceleration", 0.0);
+    angular_dynamics_.deceleration_limit_ = angular_dynamics_.acceleration_limit_ ;
+  }
+
+  // Linear dynamics constraints
+  linear_dynamics_.Configure(r.SubnodeOpt("linear_dynamics", YamlReader::MAP).Node());
+
   delta_command_ = 0.0;
   theta_f_ = 0.0;
   d_delta_ = 0.0;
@@ -351,7 +362,6 @@ void TricycleDrive::BeforePhysicsStep(const Timekeeper& timekeeper) {
   //   |d2δ[t]| <= max_steer_acceleration_
 
   // twist message contains the speed and angle of the front wheel
-  double v_f = twist_msg_.linear.x;       // target velocity at front wheel
   delta_command_ = twist_msg_.angular.z;  // target steering angle
   double theta = angle;                   // angle of robot in map frame
   double dt = timekeeper.GetStepSize();
@@ -365,24 +375,13 @@ void TricycleDrive::BeforePhysicsStep(const Timekeeper& timekeeper) {
   if (max_steer_acceleration_ == 0.0) {
     delta_max_one_step = fabs(delta_command_ - theta_f_);
   }
+
   if (fabs(delta_command_ - theta_f_) >= delta_max_one_step) {
     d_delta_command = (delta_command_ - theta_f_) / dt;
   }
-  if (max_steer_velocity_ != 0.0) {
-    // Saturating the command also saturates the steering velocity
-    d_delta_command =
-        Saturate(d_delta_command, -max_steer_velocity_, max_steer_velocity_);
-  }
 
-  // (3) Update the new steering acceleration
-  double d2_delta = (d_delta_command - d_delta_) / dt;
-  if (max_steer_acceleration_ != 0.0) {
-    d2_delta =
-        Saturate(d2_delta, -max_steer_acceleration_, max_steer_acceleration_);
-  }
-
-  // (2) Update the new steering velocity
-  d_delta_ += d2_delta * dt;
+  // Apply angular dynamics constraints
+  d_delta_ = angular_dynamics_.Limit(d_delta_, d_delta_command, dt);
 
   // (1) Update the new steering angle
   theta_f_ += d_delta_ * dt;
@@ -391,9 +390,9 @@ void TricycleDrive::BeforePhysicsStep(const Timekeeper& timekeeper) {
   }
 
   ROS_DEBUG_THROTTLE(0.5,
-                     "Using new tricycle steering, d2_delta = %.4f, "
+                     "Using new tricycle steering, "
                      "d_delta = %.4f, twist.x = %.4f, twist.delta = %.4f",
-                     d2_delta, d_delta_, twist_msg_.linear.x,
+                     d_delta_, twist_msg_.linear.x,
                      twist_msg_.angular.z);
 
   // change angle of the front wheel for visualization
@@ -410,9 +409,13 @@ void TricycleDrive::BeforePhysicsStep(const Timekeeper& timekeeper) {
   // calculate the desired velocity using the bicycle model in the world frame
   // looking at the rear center, formulas obtained from avidbots robot systems
   // confluence page
-  double v_x = v_f * cos(theta_f_) * cos(theta);  // x velocity in world
-  double v_y = v_f * cos(theta_f_) * sin(theta);  // y velocity in world
-  double w = v_f * sin(theta_f_) / wheelbase_;    // angular velocity
+
+  // apply linear velocity and acceleration constraints
+  v_f_ = linear_dynamics_.Limit(v_f_, twist_msg_.linear.x, dt);
+
+  double v_x = v_f_ * cos(theta_f_) * cos(theta);  // x velocity in world
+  double v_y = v_f_ * cos(theta_f_) * sin(theta);  // y velocity in world
+  double w = v_f_ * sin(theta_f_) / wheelbase_;    // angular velocity
 
   // Now we would like the rear center to move at v_x, v_y, and w, since Box2D
   // applies velocities at center of mass, we must use rigid body kinematics

--- a/flatland_plugins/test/dynamics_limits_test.cpp
+++ b/flatland_plugins/test/dynamics_limits_test.cpp
@@ -206,35 +206,35 @@ TEST(DynamicsLimitsTest, test_Saturate) {
   auto dynamics_limits = DynamicsLimits();
   double result;
   // Useless, strict bounds
-  result = dynamics_limits.Saturate(0, 0, 0);  // Bound between 0 and 0, 0
+  result = DynamicsLimits::Saturate(0, 0, 0);  // Bound between 0 and 0, 0
   EXPECT_NEAR(0, result, 1e-3);
-  result = dynamics_limits.Saturate(1, 0, 0);  // Bound between 1 and 0, 0
+  result = DynamicsLimits::Saturate(1, 0, 0);  // Bound between 1 and 0, 0
   EXPECT_NEAR(0, result, 1e-3);
-  result = dynamics_limits.Saturate(-1, 0, 0);  // Bound between -1 and 0, 0
+  result = DynamicsLimits::Saturate(-1, 0, 0);  // Bound between -1 and 0, 0
   EXPECT_NEAR(0, result, 1e-3);
 
   // Valid bounds
-  result = dynamics_limits.Saturate(0, -1.1, 2.2);
+  result = DynamicsLimits::Saturate(0, -1.1, 2.2);
   EXPECT_NEAR(0, result, 1e-3);
-  result = dynamics_limits.Saturate(1, -1.1, 2.2);
+  result = DynamicsLimits::Saturate(1, -1.1, 2.2);
   EXPECT_NEAR(1, result, 1e-3);
-  result = dynamics_limits.Saturate(-1,  -1.1, 2.2);
+  result = DynamicsLimits::Saturate(-1,  -1.1, 2.2);
   EXPECT_NEAR(-1, result, 1e-3);
-  result = dynamics_limits.Saturate(3, -1.1, 2.2);
+  result = DynamicsLimits::Saturate(3, -1.1, 2.2);
   EXPECT_NEAR(2.2, result, 1e-3);
-  result = dynamics_limits.Saturate(-3,  -1.1, 2.2);
+  result = DynamicsLimits::Saturate(-3,  -1.1, 2.2);
   EXPECT_NEAR(-1.1, result, 1e-3);
 
   // Invalid bounds, input not changed
-  result = dynamics_limits.Saturate(0, 1.1, -2.2);
+  result = DynamicsLimits::Saturate(0, 1.1, -2.2);
   EXPECT_NEAR(0, result, 1e-3);
-  result = dynamics_limits.Saturate(1, 1.1, -2.2);
+  result = DynamicsLimits::Saturate(1, 1.1, -2.2);
   EXPECT_NEAR(1, result, 1e-3);
-  result = dynamics_limits.Saturate(-1,  1.1, -2.2);
+  result = DynamicsLimits::Saturate(-1,  1.1, -2.2);
   EXPECT_NEAR(-1, result, 1e-3);
-  result = dynamics_limits.Saturate(3, 1.1, -2.2);
+  result = DynamicsLimits::Saturate(3, 1.1, -2.2);
   EXPECT_NEAR(3, result, 1e-3);
-  result = dynamics_limits.Saturate(-3,  1.1, -2.2);
+  result = DynamicsLimits::Saturate(-3,  1.1, -2.2);
   EXPECT_NEAR(-3, result, 1e-3);
 }
 

--- a/flatland_plugins/test/dynamics_limits_test.cpp
+++ b/flatland_plugins/test/dynamics_limits_test.cpp
@@ -1,0 +1,316 @@
+/*
+ *  ______                   __  __              __
+ * /\  _  \           __    /\ \/\ \            /\ \__
+ * \ \ \L\ \  __  __ /\_\   \_\ \ \ \____    ___\ \ ,_\   ____
+ *  \ \  __ \/\ \/\ \\/\ \  /'_` \ \ '__`\  / __`\ \ \/  /',__\
+ *   \ \ \/\ \ \ \_/ |\ \ \/\ \L\ \ \ \L\ \/\ \L\ \ \ \_/\__, `\
+ *    \ \_\ \_\ \___/  \ \_\ \___,_\ \_,__/\ \____/\ \__\/\____/
+ *     \/_/\/_/\/__/    \/_/\/__,_ /\/___/  \/___/  \/__/\/___/
+ * @copyright Copyright 2021 Avidbots Corp.
+ * @name  dynamics_limits_test.cpp
+ * @brief Test dynamics limits class
+ * @author Joseph Duchesne
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Avidbots Corp.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Avidbots Corp. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <flatland_plugins/dynamics_limits.h>
+#include <flatland_server/yaml_reader.h>
+#include <yaml-cpp/yaml.h>
+#include <gtest/gtest.h>
+
+using namespace flatland_plugins;
+
+/**
+ * Test loading blank parameters
+ */
+TEST(DynamicsLimitsTest, test_Configure_blank) {
+  auto dynamics_limits = DynamicsLimits();
+
+  // Ensure defaults are zero
+  EXPECT_NEAR(0.0, dynamics_limits.acceleration_limit_, 1e-3);
+  EXPECT_NEAR(0.0, dynamics_limits.deceleration_limit_, 1e-3);
+  EXPECT_NEAR(0.0, dynamics_limits.velocity_limit_, 1e-3);
+}
+
+
+/**
+ * Test loading blank parameters
+ */
+TEST(DynamicsLimitsTest, test_Configure_empty_yaml) {
+  auto dynamics_limits = DynamicsLimits();
+  YAML::Node config = YAML::Node();
+  dynamics_limits.Configure(config);
+
+  // Ensure defaults are zero
+  EXPECT_NEAR(0.0, dynamics_limits.acceleration_limit_, 1e-3);
+  EXPECT_NEAR(0.0, dynamics_limits.deceleration_limit_, 1e-3);
+  EXPECT_NEAR(0.0, dynamics_limits.velocity_limit_, 1e-3);
+}
+
+
+/**
+ * Test loading acceleration+velocity parameters
+ */
+TEST(DynamicsLimitsTest, test_Configure_two_params) {
+  auto dynamics_limits = DynamicsLimits();
+
+  YAML::Node config = YAML::Node();
+  config["acceleration_limit"] = 0.1;
+  config["velocity_limit"] = 2.0;
+  dynamics_limits.Configure(config);
+
+  // Ensure defaults are zero
+  EXPECT_NEAR(0.1, dynamics_limits.acceleration_limit_, 1e-3);
+  // deccelleration cap defaults to accleration cap if not set
+  EXPECT_NEAR(0.1, dynamics_limits.deceleration_limit_, 1e-3);
+  EXPECT_NEAR(2.0, dynamics_limits.velocity_limit_, 1e-3);
+}
+
+/**
+ * Test loading acceleration, deceleration, velocity parameters
+ */
+TEST(DynamicsLimitsTest, test_Configure_three_params) {
+  auto dynamics_limits = DynamicsLimits();
+
+  YAML::Node config = YAML::Node();
+  config["acceleration_limit"] = 0.1;
+  config["deceleration_limit"] = 0.2;
+  config["velocity_limit"] = 2.0;
+  dynamics_limits.Configure(config);
+
+  // Ensure params are correct
+  EXPECT_NEAR(0.1, dynamics_limits.acceleration_limit_, 1e-3);
+  EXPECT_NEAR(0.2, dynamics_limits.deceleration_limit_, 1e-3);
+  EXPECT_NEAR(2.0, dynamics_limits.velocity_limit_, 1e-3);
+}
+
+// todo: test Saturate
+
+/**
+ * Test Limit function without dynamics limits in place
+ */
+TEST(DynamicsLimitsTest, test_Limit_noop) {
+  auto dynamics_limits = DynamicsLimits();
+
+  double result;
+  result = dynamics_limits.Limit(0, 1.0, 0.05);
+  EXPECT_NEAR(1.0, result, 1e-3);
+  result = dynamics_limits.Limit(1.0, 1.0, 0.05);
+  EXPECT_NEAR(1.0, result, 1e-3);
+  result = dynamics_limits.Limit(0.1, 1.0, 0.05);
+  EXPECT_NEAR(1.0, result, 1e-3);
+  result = dynamics_limits.Limit(-100, 1.0, 0.1);
+  EXPECT_NEAR(1.0, result, 1e-3);
+  result = dynamics_limits.Limit(-100, -1.0, 0.1);
+  EXPECT_NEAR(-1.0, result, 1e-3);
+  result = dynamics_limits.Limit(-100, -21.0, 0.1);
+  EXPECT_NEAR(-21.0, result, 1e-3);
+}
+
+
+/**
+ * Test Limit function
+ */
+TEST(DynamicsLimitsTest, test_Limit_velocity) {
+  auto dynamics_limits = DynamicsLimits();
+
+  YAML::Node config = YAML::Node();
+  config["velocity_limit"] = 1.0;
+  dynamics_limits.Configure(config);
+
+  EXPECT_NEAR(0.0, dynamics_limits.acceleration_limit_, 1e-3);
+  EXPECT_NEAR(0.0, dynamics_limits.deceleration_limit_, 1e-3);
+  EXPECT_NEAR(1.0, dynamics_limits.velocity_limit_, 1e-3);
+
+  double result;
+  result = dynamics_limits.Limit(0, 1.0, 0.05);
+  EXPECT_NEAR(1.0, result, 1e-3);
+  result = dynamics_limits.Limit(1.0, 1.0, 0.05);
+  EXPECT_NEAR(1.0, result, 1e-3);
+  result = dynamics_limits.Limit(0, 2.0, 0.05);
+  EXPECT_NEAR(1.0, result, 1e-3);
+  result = dynamics_limits.Limit(0, -1.0, 0.1);
+  EXPECT_NEAR(-1.0, result, 1e-3);
+  result = dynamics_limits.Limit(0, -0.5, 0.1);
+  EXPECT_NEAR(-0.5, result, 1e-3);
+  result = dynamics_limits.Limit(1.0, -0.5, 0.1);
+  EXPECT_NEAR(-0.5, result, 1e-3);
+  result = dynamics_limits.Limit(-100, -1.0, 0.1);
+  EXPECT_NEAR(-1.0, result, 1e-3);
+  result = dynamics_limits.Limit(0, -3.0, 0.1);
+  EXPECT_NEAR(-1.0, result, 1e-3);
+}
+
+
+/**
+ * Test Limit function wrt. acceleration
+ */
+TEST(DynamicsLimitsTest, test_Limit_acceleration) {
+  auto dynamics_limits = DynamicsLimits();
+
+  YAML::Node config = YAML::Node();
+  config["acceleration_limit"] = 9.0;
+  dynamics_limits.Configure(config);
+
+  EXPECT_NEAR(9.0, dynamics_limits.acceleration_limit_, 1e-3);
+  EXPECT_NEAR(9.0, dynamics_limits.deceleration_limit_, 1e-3);
+  EXPECT_NEAR(0.0, dynamics_limits.velocity_limit_, 1e-3);
+
+  double result;
+  result = dynamics_limits.Limit(0, 1.0, 0.05);  // Try to accelerate at 20m/s/s, when the limit is 9
+  EXPECT_NEAR(0.45, result, 1e-3);
+  result = dynamics_limits.Limit(1.0, 0.0, 0.05);  // Try to deccelerate at -20m/s/s, when the limit is 9
+  EXPECT_NEAR(0.55, result, 1e-3);
+  result = dynamics_limits.Limit(10.0, 0.0, 0.05);  // Try to deccelerate at -20m/s/s, when the limit is 9
+  EXPECT_NEAR(9.55, result, 1e-3);
+  result = dynamics_limits.Limit(-10.0, 0.0, 0.05);  // Try to deccelerate at 20m/s/s, when the limit is 9
+  EXPECT_NEAR(-9.55, result, 1e-3);
+  result = dynamics_limits.Limit(5, -5, 0.05);  // Try to deccelerate at 20m/s/s, when the limit is 9
+  EXPECT_NEAR(4.55, result, 1e-3);
+  result = dynamics_limits.Limit(-3, -2, 0.05);  // Try to deccelerate at 20m/s/s, when the limit is 9
+  EXPECT_NEAR(-2.55, result, 1e-3);
+}
+
+TEST(DynamicsLimitsTest, test_Saturate) {
+  auto dynamics_limits = DynamicsLimits();
+  double result;
+  // Useless, strict bounds
+  result = dynamics_limits.Saturate(0, 0, 0);  // Bound between 0 and 0, 0
+  EXPECT_NEAR(0, result, 1e-3);
+  result = dynamics_limits.Saturate(1, 0, 0);  // Bound between 1 and 0, 0
+  EXPECT_NEAR(0, result, 1e-3);
+  result = dynamics_limits.Saturate(-1, 0, 0);  // Bound between -1 and 0, 0
+  EXPECT_NEAR(0, result, 1e-3);
+
+  // Valid bounds
+  result = dynamics_limits.Saturate(0, -1.1, 2.2);
+  EXPECT_NEAR(0, result, 1e-3);
+  result = dynamics_limits.Saturate(1, -1.1, 2.2);
+  EXPECT_NEAR(1, result, 1e-3);
+  result = dynamics_limits.Saturate(-1,  -1.1, 2.2);
+  EXPECT_NEAR(-1, result, 1e-3);
+  result = dynamics_limits.Saturate(3, -1.1, 2.2);
+  EXPECT_NEAR(2.2, result, 1e-3);
+  result = dynamics_limits.Saturate(-3,  -1.1, 2.2);
+  EXPECT_NEAR(-1.1, result, 1e-3);
+
+  // Invalid bounds, input not changed
+  result = dynamics_limits.Saturate(0, 1.1, -2.2);
+  EXPECT_NEAR(0, result, 1e-3);
+  result = dynamics_limits.Saturate(1, 1.1, -2.2);
+  EXPECT_NEAR(1, result, 1e-3);
+  result = dynamics_limits.Saturate(-1,  1.1, -2.2);
+  EXPECT_NEAR(-1, result, 1e-3);
+  result = dynamics_limits.Saturate(3, 1.1, -2.2);
+  EXPECT_NEAR(3, result, 1e-3);
+  result = dynamics_limits.Saturate(-3,  1.1, -2.2);
+  EXPECT_NEAR(-3, result, 1e-3);
+}
+
+/**
+ * Test Limit function wrt. acceleration asnd decelleration
+ */
+TEST(DynamicsLimitsTest, test_Limit_deceleration) {
+  auto dynamics_limits = DynamicsLimits();
+
+  YAML::Node config = YAML::Node();
+  config["acceleration_limit"] = 1.0;
+  config["deceleration_limit"] = 9.0;
+  dynamics_limits.Configure(config);
+
+  EXPECT_NEAR(1.0, dynamics_limits.acceleration_limit_, 1e-3);
+  EXPECT_NEAR(9.0, dynamics_limits.deceleration_limit_, 1e-3);
+  EXPECT_NEAR(0.0, dynamics_limits.velocity_limit_, 1e-3);
+
+  double result;
+  result = dynamics_limits.Limit(0, 1.0, 0.05);  // Try to accelerate at 20m/s/s, when the limit is 1 (acceleration)
+  EXPECT_NEAR(0.05, result, 1e-3);
+  result = dynamics_limits.Limit(0.97, 1.0, 0.05);  // Try to accelerate at <1m/s/s, when the limit is 1
+  EXPECT_NEAR(1.0, result, 1e-3);
+  result = dynamics_limits.Limit(1.0, 0.0, 0.05);  // Try to deccelerate at <20m/s/s, when the limit is 9
+  EXPECT_NEAR(0.55, result, 1e-3);
+  result = dynamics_limits.Limit(-1.0, -2.0, 0.05);  // Try to acccelerate at <20m/s/s, when the limit is 1
+  EXPECT_NEAR(-1.05, result, 1e-3);
+  result = dynamics_limits.Limit(-2.0, -1.0, 0.05);  // Try to decccelerate at <20m/s/s, when the limit is 9
+  EXPECT_NEAR(-1.55, result, 1e-3);
+  result = dynamics_limits.Limit(-2.0, 1.0, 0.05);  // Try to decccelerate at <20m/s/s, when the limit is 9
+  EXPECT_NEAR(-1.55, result, 1e-3);
+  result = dynamics_limits.Limit(-1.0, 2.0, 0.05);  // Try to decccelerate at <20m/s/s, when the limit is 9
+  EXPECT_NEAR(-0.55, result, 1e-3);
+  result = dynamics_limits.Limit(1.0, 3.0, 0.05);  // Try to acccelerate at <20m/s/s, when the limit is 1
+  EXPECT_NEAR(1.05, result, 1e-3);
+  result = dynamics_limits.Limit(3.0, -1.0, 0.05);  // Try to decccelerate at <20m/s/s, when the limit is 9
+  EXPECT_NEAR(2.55, result, 1e-3);
+}
+
+/**
+ * Test Limit function wrt. acceleration asnd decelleration
+ */
+TEST(DynamicsLimitsTest, test_Limit_acceleration_and_velocity) {
+  auto dynamics_limits = DynamicsLimits();
+
+  YAML::Node config = YAML::Node();
+  config["acceleration_limit"] = 1.0;
+  config["deceleration_limit"] = 9.0;
+  config["velocity_limit"] = 0.5;
+  dynamics_limits.Configure(config);
+
+  EXPECT_NEAR(1.0, dynamics_limits.acceleration_limit_, 1e-3);
+  EXPECT_NEAR(9.0, dynamics_limits.deceleration_limit_, 1e-3);
+  EXPECT_NEAR(0.5, dynamics_limits.velocity_limit_, 1e-3);
+
+  double result;
+  result = dynamics_limits.Limit(0, 1.0, 0.05);  // Try to accelerate at 20m/s/s, when the limit is 1 (acceleration)
+  EXPECT_NEAR(0.05, result, 1e-3);
+
+  result = dynamics_limits.Limit(0.48, 1.48, 0.05);  // Same, but hit the velocity limit
+  EXPECT_NEAR(0.5, result, 1e-3);
+
+  result = dynamics_limits.Limit(1.0, 2.0, 0.05);  // Same, but we're already over the velocity limit
+  // The invalid input temporarily results in invalid output, because we have to voilate either decelleration  or velocity constraints
+  // In this case, we violate velocity constraints
+  EXPECT_NEAR(0.55, result, 1e-3);
+
+  result = dynamics_limits.Limit(0.55, 2.0, 0.05);  // Same, but we're already over the velocity limit, 
+  // but this time we can achieve velocity constraints without violating decelleration constraints
+  EXPECT_NEAR(0.5, result, 1e-3);
+}
+
+
+
+// Run all the tests that were declared with TEST()
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/flatland_plugins/test/dynamics_limits_test.cpp
+++ b/flatland_plugins/test/dynamics_limits_test.cpp
@@ -190,15 +190,15 @@ TEST(DynamicsLimitsTest, test_Limit_acceleration) {
   double result;
   result = dynamics_limits.Limit(0, 1.0, 0.05);  // Try to accelerate at 20m/s/s, when the limit is 9
   EXPECT_NEAR(0.45, result, 1e-3);
-  result = dynamics_limits.Limit(1.0, 0.0, 0.05);  // Try to deccelerate at -20m/s/s, when the limit is 9
+  result = dynamics_limits.Limit(1.0, 0.0, 0.05);  // Try to decelerate at -20m/s/s, when the limit is 9
   EXPECT_NEAR(0.55, result, 1e-3);
-  result = dynamics_limits.Limit(10.0, 0.0, 0.05);  // Try to deccelerate at -20m/s/s, when the limit is 9
+  result = dynamics_limits.Limit(10.0, 0.0, 0.05);  // Try to decelerate at -20m/s/s, when the limit is 9
   EXPECT_NEAR(9.55, result, 1e-3);
-  result = dynamics_limits.Limit(-10.0, 0.0, 0.05);  // Try to deccelerate at 20m/s/s, when the limit is 9
+  result = dynamics_limits.Limit(-10.0, 0.0, 0.05);  // Try to decelerate at 20m/s/s, when the limit is 9
   EXPECT_NEAR(-9.55, result, 1e-3);
-  result = dynamics_limits.Limit(5, -5, 0.05);  // Try to deccelerate at 20m/s/s, when the limit is 9
+  result = dynamics_limits.Limit(5, -5, 0.05);  // Try to decelerate at 20m/s/s, when the limit is 9
   EXPECT_NEAR(4.55, result, 1e-3);
-  result = dynamics_limits.Limit(-3, -2, 0.05);  // Try to deccelerate at 20m/s/s, when the limit is 9
+  result = dynamics_limits.Limit(-3, -2, 0.05);  // Try to decelerate at 20m/s/s, when the limit is 9
   EXPECT_NEAR(-2.55, result, 1e-3);
 }
 
@@ -256,21 +256,21 @@ TEST(DynamicsLimitsTest, test_Limit_deceleration) {
   double result;
   result = dynamics_limits.Limit(0, 1.0, 0.05);  // Try to accelerate at 20m/s/s, when the limit is 1 (acceleration)
   EXPECT_NEAR(0.05, result, 1e-3);
-  result = dynamics_limits.Limit(0.97, 1.0, 0.05);  // Try to accelerate at <1m/s/s, when the limit is 1
+  result = dynamics_limits.Limit(0.97, 1.0, 0.05);  // Try to accelerate at 1m/s/s, when the limit is 1
   EXPECT_NEAR(1.0, result, 1e-3);
-  result = dynamics_limits.Limit(1.0, 0.0, 0.05);  // Try to deccelerate at <20m/s/s, when the limit is 9
+  result = dynamics_limits.Limit(1.0, 0.0, 0.05);  // Try to decelerate at 20m/s/s, when the limit is 9
   EXPECT_NEAR(0.55, result, 1e-3);
-  result = dynamics_limits.Limit(-1.0, -2.0, 0.05);  // Try to acccelerate at <20m/s/s, when the limit is 1
+  result = dynamics_limits.Limit(-1.0, -2.0, 0.05);  // Try to acccelerate at 20m/s/s, when the limit is 1
   EXPECT_NEAR(-1.05, result, 1e-3);
-  result = dynamics_limits.Limit(-2.0, -1.0, 0.05);  // Try to decccelerate at <20m/s/s, when the limit is 9
+  result = dynamics_limits.Limit(-2.0, -1.0, 0.05);  // Try to decelerate at 20m/s/s, when the limit is 9
   EXPECT_NEAR(-1.55, result, 1e-3);
-  result = dynamics_limits.Limit(-2.0, 1.0, 0.05);  // Try to decccelerate at <20m/s/s, when the limit is 9
+  result = dynamics_limits.Limit(-2.0, 1.0, 0.05);  // Try to decelerate at 20m/s/s, when the limit is 9
   EXPECT_NEAR(-1.55, result, 1e-3);
-  result = dynamics_limits.Limit(-1.0, 2.0, 0.05);  // Try to decccelerate at <20m/s/s, when the limit is 9
+  result = dynamics_limits.Limit(-1.0, 2.0, 0.05);  // Try to decelerate at 20m/s/s, when the limit is 9
   EXPECT_NEAR(-0.55, result, 1e-3);
-  result = dynamics_limits.Limit(1.0, 3.0, 0.05);  // Try to acccelerate at <20m/s/s, when the limit is 1
+  result = dynamics_limits.Limit(1.0, 3.0, 0.05);  // Try to acccelerate at 20m/s/s, when the limit is 1
   EXPECT_NEAR(1.05, result, 1e-3);
-  result = dynamics_limits.Limit(3.0, -1.0, 0.05);  // Try to decccelerate at <20m/s/s, when the limit is 9
+  result = dynamics_limits.Limit(3.0, -1.0, 0.05);  // Try to decelerate at 20m/s/s, when the limit is 9
   EXPECT_NEAR(2.55, result, 1e-3);
 }
 

--- a/flatland_plugins/test/dynamics_limits_test.cpp
+++ b/flatland_plugins/test/dynamics_limits_test.cpp
@@ -92,7 +92,7 @@ TEST(DynamicsLimitsTest, test_Configure_two_params) {
 
   // Ensure defaults are zero
   EXPECT_NEAR(0.1, dynamics_limits.acceleration_limit_, 1e-3);
-  // deccelleration cap defaults to accleration cap if not set
+  // deceleration cap defaults to accleration cap if not set
   EXPECT_NEAR(0.1, dynamics_limits.deceleration_limit_, 1e-3);
   EXPECT_NEAR(2.0, dynamics_limits.velocity_limit_, 1e-3);
 }
@@ -192,9 +192,9 @@ TEST(DynamicsLimitsTest, test_Limit_acceleration) {
   EXPECT_NEAR(0.45, result, 1e-3);
   result = dynamics_limits.Limit(1.0, 0.0, 0.05);  // Try to decelerate at -20m/s/s, when the limit is 9
   EXPECT_NEAR(0.55, result, 1e-3);
-  result = dynamics_limits.Limit(10.0, 0.0, 0.05);  // Try to decelerate at -20m/s/s, when the limit is 9
+  result = dynamics_limits.Limit(10.0, 0.0, 0.05);  // Try to decelerate at -200m/s/s, when the limit is 9
   EXPECT_NEAR(9.55, result, 1e-3);
-  result = dynamics_limits.Limit(-10.0, 0.0, 0.05);  // Try to decelerate at 20m/s/s, when the limit is 9
+  result = dynamics_limits.Limit(-10.0, 0.0, 0.05);  // Try to decelerate at 200m/s/s, when the limit is 9
   EXPECT_NEAR(-9.55, result, 1e-3);
   result = dynamics_limits.Limit(5, -5, 0.05);  // Try to decelerate at 20m/s/s, when the limit is 9
   EXPECT_NEAR(4.55, result, 1e-3);


### PR DESCRIPTION
So Far:
- Made dynamics limits a generic class, improved its function in TricycleDrive plugin
- Added optional deceleration parameter
- Updated TricycleDrive plugin documentation.
- Added Dynamics Limits unit tests.
- Added linear dynamics to the existing angular dynamics limits for Tricycle drive
- Added dynamics limits and corresponding documentation to DiffDrive plugin