### PR TITLE
Refactor to remove compiler warnings jazzy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ docs/_templates/*
 */.history
 **/.idea/
 **/cmake-build-debug/
+build
+install
+log

--- a/flatland_plugins/src/bumper.cpp
+++ b/flatland_plugins/src/bumper.cpp
@@ -114,6 +114,9 @@ void Bumper::BeforePhysicsStep(const Timekeeper & timekeeper)
   for (it = contact_states_.begin(); it != contact_states_.end(); it++) {
     it->second.Reset();
   }
+
+  // Avoid -Wunused-parameter warnings - remove if parameter is used!
+  (void)timekeeper;
 }
 
 void Bumper::AfterPhysicsStep(const Timekeeper & timekeeper)

--- a/flatland_plugins/src/diff_drive.cpp
+++ b/flatland_plugins/src/diff_drive.cpp
@@ -162,7 +162,7 @@ void DiffDrive::OnInitialize(const YAML::Node & config)
     "twist_sub(%s) odom_pub(%s) ground_truth_pub(%s) "
     "odom_pose_noise({%f,%f,%f}) odom_twist_noise({%f,%f,%f}) "
     "pub_rate(%f)\n",
-    body_, body_->name_.c_str(), odom_frame_id.c_str(), twist_topic.c_str(), odom_topic.c_str(),
+    (void*)body_, body_->name_.c_str(), odom_frame_id.c_str(), twist_topic.c_str(), odom_topic.c_str(),
     ground_truth_topic.c_str(), odom_pose_noise[0], odom_pose_noise[1], odom_pose_noise[2],
     odom_twist_noise[0], odom_twist_noise[1], odom_twist_noise[2], pub_rate);
 }

--- a/flatland_plugins/src/laser.cpp
+++ b/flatland_plugins/src/laser.cpp
@@ -218,6 +218,10 @@ float LaserCallback::ReportFixture(
   did_hit_ = true;
   fraction_ = fraction;
 
+  // Avoid -Wunused-parameter warnings - remove if parameter is used!
+  (void)point;
+  (void)normal;
+
   return fraction;
 }
 

--- a/flatland_plugins/src/laser.cpp
+++ b/flatland_plugins/src/laser.cpp
@@ -274,7 +274,7 @@ void Laser::ParseParameters(const YAML::Node & config)
     "frame_id(%s) broadcast_tf(%d) update_rate(%f) range(%f)  "
     "noise_std_dev(%f) angle_min(%f) angle_max(%f) "
     "angle_increment(%f) layers(0x%u {%s})",
-    GetName().c_str(), topic_.c_str(), body_name.c_str(), body_, origin_.x, origin_.y,
+    GetName().c_str(), topic_.c_str(), body_name.c_str(), (void*)body_, origin_.x, origin_.y,
     origin_.theta, frame_id_.c_str(), broadcast_tf_, update_rate_, range_, noise_std_dev_,
     min_angle_, max_angle_, increment_, layers_bits_, boost::algorithm::join(layers, ",").c_str());
 }

--- a/flatland_plugins/src/model_tf_publisher.cpp
+++ b/flatland_plugins/src/model_tf_publisher.cpp
@@ -102,7 +102,7 @@ void ModelTfPublisher::OnInitialize(const YAML::Node & config)
     rclcpp::get_logger("ModelTFPublisher"),
     "Initialized with params: reference(%s, %p) "
     "publish_tf_world(%d) world_frame_id(%s) update_rate(%f), exclude({%s})",
-    reference_body_->name_.c_str(), reference_body_, publish_tf_world_, world_frame_id_.c_str(),
+    reference_body_->name_.c_str(), (void*)reference_body_, publish_tf_world_, world_frame_id_.c_str(),
     update_rate_, boost::algorithm::join(excluded_body_names, ",").c_str());
 }
 

--- a/flatland_plugins/src/tricycle_drive.cpp
+++ b/flatland_plugins/src/tricycle_drive.cpp
@@ -174,8 +174,8 @@ void TricycleDrive::OnInitialize(const YAML::Node & config)
     "odom_frame_id(%s) twist_sub(%s) odom_pub(%s) "
     "ground_truth_pub(%s) odom_pose_noise({%f,%f,%f}) "
     "odom_twist_noise({%f,%f,%f}) pub_rate(%f)\n",
-    body_, body_->GetName().c_str(), front_wj_, front_wj_->GetName().c_str(), rear_left_wj_,
-    rear_left_wj_->GetName().c_str(), rear_right_wj_, rear_right_wj_->GetName().c_str(),
+    (void*)body_, body_->GetName().c_str(), (void*)front_wj_, front_wj_->GetName().c_str(), (void*)rear_left_wj_,
+    rear_left_wj_->GetName().c_str(), (void*)rear_right_wj_, rear_right_wj_->GetName().c_str(),
     odom_frame_id.c_str(), twist_topic.c_str(), odom_topic.c_str(), ground_truth_topic.c_str(),
     odom_pose_noise[0], odom_pose_noise[1], odom_pose_noise[2], odom_twist_noise[0],
     odom_twist_noise[1], odom_twist_noise[2], pub_rate);

--- a/flatland_plugins/src/tween.cpp
+++ b/flatland_plugins/src/tween.cpp
@@ -242,7 +242,7 @@ void Tween::OnInitialize(const YAML::Node & config)
     "duration %f "
     "mode: %s [%d] "
     "easing: %s\n",
-    body_, body_->name_.c_str(), start_.x, start_.y, start_.theta, delta_.x, delta_.y, delta_.theta,
+    (void*)body_, body_->name_.c_str(), start_.x, start_.y, start_.theta, delta_.x, delta_.y, delta_.theta,
     duration_, mode.c_str(), (int)mode_, easing.c_str());
 }
 

--- a/flatland_plugins/src/world_modifier.cpp
+++ b/flatland_plugins/src/world_modifier.cpp
@@ -78,6 +78,11 @@ float RayTrace::ReportFixture(
   }
   is_hit_ = true;
   fraction_ = fraction;
+
+  // Avoid -Wunused-parameter warnings - remove if parameter is used!
+  (void)point;
+  (void)normal;
+
   return fraction;
 }
 

--- a/flatland_plugins/src/world_random_wall.cpp
+++ b/flatland_plugins/src/world_random_wall.cpp
@@ -54,6 +54,7 @@
 #include <algorithm>
 #include <iostream>
 #include <pluginlib/class_list_macros.hpp>
+#include <random>
 #include <rclcpp/rclcpp.hpp>
 #include <string>
 
@@ -113,8 +114,9 @@ void RandomWall::OnInitialize(const YAML::Node & config, YamlReader & world_conf
   for (b2Fixture * f = layer->body_->physics_body_->GetFixtureList(); f; f = f->GetNext()) {
     Wall_List.push_back(static_cast<b2EdgeShape *>(f->GetShape()));
   }
-  std::srand(std::time(0));
-  std::random_shuffle(Wall_List.begin(), Wall_List.end());
+  auto rd = std::random_device {};
+  auto rng = std::default_random_engine { rd() };
+  std::shuffle(Wall_List.begin(), Wall_List.end(), rng);
   try {
     for (unsigned int i = 0; i < num_of_walls; i++) {
       modifier.AddFullWall(Wall_List[i]);

--- a/flatland_plugins/test/laser_tests/intensity_test/robot.model.yaml
+++ b/flatland_plugins/test/laser_tests/intensity_test/robot.model.yaml
@@ -20,7 +20,7 @@ plugins:
 
   - type: Laser
     name: laser_center
-    topic: /scan_center
+    topic: scan_center
     frame: center_laser
     body: base_link
     origin: [0, 0, 0]

--- a/flatland_plugins/test/laser_tests/range_test/robot.model.yaml
+++ b/flatland_plugins/test/laser_tests/range_test/robot.model.yaml
@@ -20,7 +20,7 @@ plugins:
 
   - type: Laser
     name: laser_center
-    topic: /scan_center
+    topic: scan_center
     frame: center_laser
     body: base_link
     origin: [0, 0, 0]

--- a/flatland_plugins/test/update_timer_test.cpp
+++ b/flatland_plugins/test/update_timer_test.cpp
@@ -67,6 +67,9 @@ public:
   {
     update_timer_.SetRate(0);
     update_counter_ = 0;
+
+    // Avoid -Wunused-parameter warnings - remove if parameter is used!
+    (void)config;
   }
 
   void BeforePhysicsStep(const Timekeeper & timekeeper) override

--- a/flatland_server/include/flatland_server/model.h
+++ b/flatland_server/include/flatland_server/model.h
@@ -72,8 +72,8 @@ public:
   std::string namespace_;            ///< namespace of the model
   std::vector<ModelBody *> bodies_;  ///< list of bodies in the model
   std::vector<Joint *> joints_;      ///< list of joints in the model
-  YamlReader plugins_reader_;        ///< for storing plugins when paring YAML
   CollisionFilterRegistry * cfr_;    ///< Collision filter registry
+  YamlReader plugins_reader_;        ///< for storing plugins when paring YAML
   std::string viz_name_;             ///< used for visualization
 
   /**

--- a/flatland_server/include/flatland_server/world.h
+++ b/flatland_server/include/flatland_server/world.h
@@ -80,9 +80,9 @@ public:
   std::vector<Layer *> layers_;                  ///< list of layers
   std::vector<Model *> models_;                  ///< list of models
   CollisionFilterRegistry cfr_;                  ///< collision registry for layers and models
-  PluginManager plugin_manager_;                 ///< for loading and updating plugins
   bool service_paused_;                          ///< indicates if simulation is paused by a service
                                                  /// call or not
+  PluginManager plugin_manager_;                 ///< for loading and updating plugins
   InteractiveMarkerManager int_marker_manager_;  ///< for dynamically moving models from Rviz
   int physics_position_iterations_;              ///< Box2D solver param
   int physics_velocity_iterations_;              ///< Box2D solver param

--- a/flatland_server/src/body.cpp
+++ b/flatland_server/src/body.cpp
@@ -103,8 +103,8 @@ void Body::DebugOutput() const
     "Body %p: entity(%p, %s) name(%s) color(%f,%f,%f,%f) "
     "physics_body(%p) num_fixtures(%d) type(%d) pose(%f, %f, %f) "
     "angular_damping(%f) linear_damping(%f)",
-    this, entity_, entity_->name_.c_str(), name_.c_str(), color_.r, color_.g, color_.b, color_.a,
-    physics_body_, GetFixturesCount(), physics_body_->GetType(), physics_body_->GetPosition().x,
+    (void*)this, (void*)entity_, entity_->name_.c_str(), name_.c_str(), color_.r, color_.g, color_.b, color_.a,
+    (void*)physics_body_, GetFixturesCount(), physics_body_->GetType(), physics_body_->GetPosition().x,
     physics_body_->GetPosition().y, physics_body_->GetAngle(), physics_body_->GetAngularDamping(),
     physics_body_->GetLinearDamping());
 }

--- a/flatland_server/src/dummy_world_plugin.cpp
+++ b/flatland_server/src/dummy_world_plugin.cpp
@@ -73,6 +73,10 @@ void DummyWorldPlugin::OnInitialize(const YAML::Node & plugin_reader, YamlReader
       "\"DummyWorldPluginType\", the type is " +
       type_);
   }
+
+  // Avoid -Wunused-parameter warnings - remove if parameter is used!
+  (void)plugin_reader;
+  (void)world_config;
 }
 }  // namespace flatland_plugins
 

--- a/flatland_server/src/interactive_marker_manager.cpp
+++ b/flatland_server/src/interactive_marker_manager.cpp
@@ -193,12 +193,18 @@ void InteractiveMarkerManager::processMouseDownFeedback(
   const visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr & feedback)
 {
   manipulating_model_ = true;
+
+  // Avoid -Wunused-parameter warnings - remove if parameter is used!
+  (void)feedback;
 }
 
 void InteractiveMarkerManager::processPoseUpdateFeedback(
   const visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr & feedback)
 {
   pose_update_stamp_ = rclcpp::Clock(RCL_SYSTEM_TIME).now();
+
+  // Avoid -Wunused-parameter warnings - remove if parameter is used!
+  (void)feedback;
 }
 
 void InteractiveMarkerManager::update()

--- a/flatland_server/src/joint.cpp
+++ b/flatland_server/src/joint.cpp
@@ -202,8 +202,8 @@ void Joint::DebugOutput() const
     "Joint %p: model(%p, %s) name(%s) color(%f,%f,%f,%f) "
     "physics_joint(%p) body_A(%p, %s) anchor_A_world(%f, %f) "
     "body_B(%p, %s) anchor_B_world(%f, %f)",
-    this, model_, model_->name_.c_str(), name_.c_str(), color_.r, color_.g, color_.b, color_.a,
-    physics_joint_, body_A, body_A->name_.c_str(), j->GetAnchorA().x, j->GetAnchorA().y, body_B,
+    (void*)this, (void*)model_, model_->name_.c_str(), name_.c_str(), color_.r, color_.g, color_.b, color_.a,
+    (void*)physics_joint_, (void*)body_A, body_A->name_.c_str(), j->GetAnchorA().x, j->GetAnchorA().y, (void*)body_B,
     body_B->name_.c_str(), j->GetAnchorB().x, j->GetAnchorB().y);
 }
 

--- a/flatland_server/src/layer.cpp
+++ b/flatland_server/src/layer.cpp
@@ -105,6 +105,9 @@ Layer::Layer(
   const std::vector<std::string> & names, const Color & color, const YAML::Node & properties)
 : Entity(node, physics_world, names[0]), names_(names), cfr_(cfr), viz_name_("layers/l_" + names[0])
 {
+  // Avoid -Wunused-parameter warnings - remove if parameter is used!
+  (void)color;
+  (void)properties;
 }
 
 Layer::~Layer() { delete body_; }

--- a/flatland_server/src/layer.cpp
+++ b/flatland_server/src/layer.cpp
@@ -327,7 +327,7 @@ void Layer::DebugOutput() const
     rclcpp::get_logger("Layer"),
     "Layer %p: physics_world(%p) name(%s) names(%s) "
     "category_bits(0x%X)",
-    this, physics_world_, name_.c_str(), names.c_str(), category_bits);
+    (void*)this, (void*)physics_world_, name_.c_str(), names.c_str(), category_bits);
 
   if (body_ != nullptr) {
     body_->DebugOutput();

--- a/flatland_server/src/model.cpp
+++ b/flatland_server/src/model.cpp
@@ -285,7 +285,7 @@ void Model::DebugOutput() const
     rclcpp::get_logger("Model"),
     "Model %p: physics_world(%p) name(%s) namespace(%s) "
     "num_bodies(%lu) num_joints(%lu)",
-    this, physics_world_, name_.c_str(), namespace_.c_str(), bodies_.size(), joints_.size());
+    (void*)this, (void*)physics_world_, name_.c_str(), namespace_.c_str(), bodies_.size(), joints_.size());
 
   for (const auto & body : bodies_) {
     body->DebugOutput();

--- a/flatland_server/src/service_manager.cpp
+++ b/flatland_server/src/service_manager.cpp
@@ -107,6 +107,9 @@ bool ServiceManager::ChangeRate(
     response->message = std::string(e.what());
   }
 
+  // Avoid -Wunused-parameter warnings - remove if parameter is used!
+  (void)request_header;
+
   return true;
 }
 
@@ -135,6 +138,9 @@ bool ServiceManager::SpawnModel(
       rclcpp::get_logger("ServiceManager"), "Failed to load model! Exception: %s", e.what());
   }
 
+  // Avoid -Wunused-parameter warnings - remove if parameter is used!
+  (void)request_header;
+
   return true;
 }
 
@@ -155,6 +161,9 @@ bool ServiceManager::DeleteModel(
     response->success = false;
     response->message = std::string(e.what());
   }
+
+  // Avoid -Wunused-parameter warnings - remove if parameter is used!
+  (void)request_header;
 
   return true;
 }
@@ -179,6 +188,9 @@ bool ServiceManager::MoveModel(
     response->message = std::string(e.what());
   }
 
+  // Avoid -Wunused-parameter warnings - remove if parameter is used!
+  (void)request_header;
+
   return true;
 }
 
@@ -188,6 +200,12 @@ bool ServiceManager::Pause(
   std::shared_ptr<std_srvs::srv::Empty::Response> response)
 {
   world_->Pause();
+
+  // Avoid -Wunused-parameter warnings - remove if parameter is used!
+  (void)request_header;
+  (void)request;
+  (void)response;
+
   return true;
 }
 
@@ -197,6 +215,12 @@ bool ServiceManager::Resume(
   std::shared_ptr<std_srvs::srv::Empty::Response> response)
 {
   world_->Resume();
+
+  // Avoid -Wunused-parameter warnings - remove if parameter is used!
+  (void)request_header;
+  (void)request;
+  (void)response;
+
   return true;
 }
 
@@ -206,6 +230,12 @@ bool ServiceManager::TogglePause(
   std::shared_ptr<std_srvs::srv::Empty::Response> response)
 {
   world_->TogglePaused();
+
+  // Avoid -Wunused-parameter warnings - remove if parameter is used!
+  (void)request_header;
+  (void)request;
+  (void)response;
+
   return true;
 }
 };  // namespace flatland_server

--- a/flatland_server/test/plugin_manager_test.cpp
+++ b/flatland_server/test/plugin_manager_test.cpp
@@ -86,16 +86,27 @@ public:
     function_called["PostSolve"] = false;
   }
 
-  void OnInitialize(const YAML::Node & config) override { function_called["OnInitialize"] = true; }
+  void OnInitialize(const YAML::Node & config) override {
+    function_called["OnInitialize"] = true;
+
+    // Avoid -Wunused-parameter warnings - remove if parameter is used!
+    (void)config;
+  }
 
   void BeforePhysicsStep(const Timekeeper & timekeeper) override
   {
     function_called["BeforePhysicsStep"] = true;
+
+    // Avoid -Wunused-parameter warnings - remove if parameter is used!
+    (void)timekeeper;
   }
 
   void AfterPhysicsStep(const Timekeeper & timekeeper) override
   {
     function_called["AfterPhysicsStep"] = true;
+
+    // Avoid -Wunused-parameter warnings - remove if parameter is used!
+    (void)timekeeper;
   }
 
   void BeginContact(b2Contact * contact) override
@@ -114,12 +125,18 @@ public:
   {
     function_called["PreSolve"] = true;
     FilterContact(contact, entity, fixture_A, fixture_B);
+
+    // Avoid -Wunused-parameter warnings - remove if parameter is used!
+    (void)oldManifold;
   }
 
   void PostSolve(b2Contact * contact, const b2ContactImpulse * impulse) override
   {
     function_called["PostSolve"] = true;
     FilterContact(contact, entity, fixture_A, fixture_B);
+
+    // Avoid -Wunused-parameter warnings - remove if parameter is used!
+    (void)impulse;
   }
 };
 


### PR DESCRIPTION
Made some refactoring changes to avoid compiler warnings on gcc 13.2.0.
The most drastic changes are to call `(void)param` to avoid [-Wunused-parameter] warnings for input argument `param`, and to replace std::random_shuffle with std::shuffle using a randomizer from <random>.