### PR TITLE
[ROS-O] add missing includes

### DIFF
--- a/flatland_server/include/flatland_server/collision_filter_registry.h
+++ b/flatland_server/include/flatland_server/collision_filter_registry.h
@@ -47,6 +47,7 @@
 #ifndef FLATLAND_SERVER_COLLISION_FILTER_REGISTRY_H
 #define FLATLAND_SERVER_COLLISION_FILTER_REGISTRY_H
 
+#include <cstdint>
 #include <map>
 #include <string>
 #include <vector>

--- a/flatland_server/include/flatland_server/types.h
+++ b/flatland_server/include/flatland_server/types.h
@@ -46,6 +46,7 @@
 
 #include <Box2D/Box2D.h>
 #include <geometry_msgs/Pose2D.h>
+#include <array>
 
 #ifndef FLATLAND_SERVER_TYPES_H
 #define FLATLAND_SERVER_TYPES_H


### PR DESCRIPTION
The headers were not needed (but used) before, but build fails on ROS-O / Debian bookworm.

These are fully backward compatible.