### PR TITLE
use specified colors in interactive marker bodies

### DIFF
--- a/flatland_server/src/world.cpp
+++ b/flatland_server/src/world.cpp
@@ -281,7 +281,7 @@ void World::LoadModel(const std::string &model_yaml_path, const std::string &ns,
   visualization_msgs::MarkerArray body_markers;
   for (size_t i = 0; i < m->bodies_.size(); i++) {
     DebugVisualization::Get().BodyToMarkers(
-        body_markers, m->bodies_[i]->physics_body_, 1.0, 0.0, 0.0, 1.0);
+        body_markers, m->bodies_[i]->physics_body_, m->bodies_[i]->color_.r, m->bodies_[i]->color_.g, m->bodies_[i]->color_.b, m->bodies_[i]->color_.a);
   }
   int_marker_manager_.createInteractiveMarker(name, pose, body_markers);
 


### PR DESCRIPTION
Thank you so much for the project. I used it in research before and am currently adapting it for university teaching.

Without this patch, detector zones for bodies can become huge obfuscating markers in rviz.

I played around with https://github.com/avidbots/turtlebot_flatland and the first impression is a big red sphere in rviz:

<img width="533" height="501" alt="screenshot250917-163433" src="https://github.com/user-attachments/assets/9f649a59-28e5-4540-83d4-1616491e9ae4" />

with the patch this uses the color specified in the configuration:

<img width="487" height="440" alt="screenshot250917-163207" src="https://github.com/user-attachments/assets/6fa8e7f5-487d-4964-bcb0-79a750ce5ad0" />
