### PR TITLE
feat(rr): squash-merge rr-devel changes onto upstream/master

### DIFF
--- a/flatland_msgs/srv/SpawnModel.srv
+++ b/flatland_msgs/srv/SpawnModel.srv
@@ -1,4 +1,4 @@
-string yaml_path
+string yaml_name
 string name
 string ns
 geometry_msgs/Pose2D pose

--- a/flatland_plugins/CMakeLists.txt
+++ b/flatland_plugins/CMakeLists.txt
@@ -150,9 +150,9 @@ if(CATKIN_ENABLE_TESTING)
                     test/tricycle_drive_test.cpp)
   target_link_libraries(tricycle_drive_test flatland_plugins_lib)
 
-  add_rostest_gtest(diff_drive_test test/diff_drive_test.test
+  add_rostest_gtest(diff_drive_plugin_test test/diff_drive_test.test
                     test/diff_drive_test.cpp)
-  target_link_libraries(diff_drive_test flatland_plugins_lib)
+  target_link_libraries(diff_drive_plugin_test flatland_plugins_lib)
 
   add_rostest_gtest(imu_test test/imu_test.test
                     test/imu_test.cpp)

--- a/flatland_plugins/include/flatland_plugins/diff_drive.h
+++ b/flatland_plugins/include/flatland_plugins/diff_drive.h
@@ -79,6 +79,7 @@ class DiffDrive : public flatland_server::ModelPlugin {
   bool twist_in_local_frame_;  ///< YAML parameter to publish velocity in local
                                /// frame. Original diff drive plugin publishes
                                /// local velocity wrt to odom frame
+  bool enable_ground_truth_pub_;   ///< YAML parameter to enable ground truth publishing
   DynamicsLimits angular_dynamics_; ///< Angular dynamics constraints
   DynamicsLimits linear_dynamics_;  ///< Linear dynamics constraints
   double angular_velocity_ = 0.0;

--- a/flatland_plugins/src/diff_drive.cpp
+++ b/flatland_plugins/src/diff_drive.cpp
@@ -66,7 +66,7 @@ void DiffDrive::OnInitialize(const YAML::Node& config) {
   enable_odom_tf_pub_ = reader.Get<bool>("enable_odom_tf_pub", true);
   enable_twist_pub_ = reader.Get<bool>("enable_twist_pub", true);
   twist_in_local_frame_ = reader.Get<bool>("twist_in_local_frame", true);
-
+  enable_ground_truth_pub_ = reader.Get<bool>("enable_ground_truth_pub", true);
   std::string body_name = reader.Get<std::string>("body");
   std::string odom_frame_id = reader.Get<std::string>("odom_frame_id", "odom");
   std::string ground_truth_frame_id =
@@ -124,6 +124,9 @@ void DiffDrive::OnInitialize(const YAML::Node& config) {
   twist_sub_ = nh_.subscribe(twist_topic, 1, &DiffDrive::TwistCallback, this);
   if (enable_odom_pub_) {
     odom_pub_ = nh_.advertise<nav_msgs::Odometry>(odom_topic, 1);
+  }
+
+  if (enable_ground_truth_pub_) {
     ground_truth_pub_ =
         nh_.advertise<nav_msgs::Odometry>(ground_truth_topic, 1);
   }
@@ -213,9 +216,10 @@ void DiffDrive::BeforePhysicsStep(const Timekeeper& timekeeper) {
   // Update odom+ground truth messages if needed
 
   if (publish) {
-    // get the state of the body and publish the data
-    b2Vec2 linear_vel_local =
-        b2body->GetLinearVelocityFromLocalPoint(b2Vec2(0, 0));
+    // get the velocity of the body, and convert to body frame, as required by
+    // http://docs.ros.org/melodic/api/nav_msgs/html/msg/Odometry.html
+    b2Vec2 linear_vel_local = b2body->GetLocalVector(
+        b2body->GetLinearVelocityFromLocalPoint(b2Vec2(0, 0)));
     float angular_vel = b2body->GetAngularVelocity();
 
     ground_truth_msg_.header.stamp = timekeeper.GetSimTime();
@@ -250,12 +254,16 @@ void DiffDrive::BeforePhysicsStep(const Timekeeper& timekeeper) {
     odom_msg_.pose.pose.orientation =
         tf::createQuaternionMsgFromYaw(angle + noise_gen_[2](rng_));
     odom_msg_.twist.twist.linear.x += noise_gen_[3](rng_);
-    odom_msg_.twist.twist.linear.y += noise_gen_[4](rng_);
+    // set to zero, since differential drive
+    odom_msg_.twist.twist.linear.y = 0;
     odom_msg_.twist.twist.angular.z += noise_gen_[5](rng_);
 
     if (enable_odom_pub_) {
-      ground_truth_pub_.publish(ground_truth_msg_);
       odom_pub_.publish(odom_msg_);
+    }
+
+    if (enable_ground_truth_pub_) {
+      ground_truth_pub_.publish(ground_truth_msg_);
     }
 
     if (enable_twist_pub_) {
@@ -292,7 +300,7 @@ void DiffDrive::BeforePhysicsStep(const Timekeeper& timekeeper) {
   }
 
 }
-}
+}  // namespace flatland_plugins
 
 PLUGINLIB_EXPORT_CLASS(flatland_plugins::DiffDrive,
                        flatland_server::ModelPlugin)

--- a/flatland_plugins/src/laser.cpp
+++ b/flatland_plugins/src/laser.cpp
@@ -48,6 +48,7 @@
 #include <flatland_server/collision_filter_registry.h>
 #include <flatland_server/exceptions.h>
 #include <flatland_server/model_plugin.h>
+#include <flatland_server/profiler.h>
 #include <flatland_server/yaml_reader.h>
 #include <geometry_msgs/TransformStamped.h>
 #include <pluginlib/class_list_macros.h>
@@ -113,8 +114,7 @@ void Laser::OnInitialize(const YAML::Node& config) {
   else
     laser_scan_.intensities.resize(0);
   laser_scan_.header.seq = 0;
-  laser_scan_.header.frame_id =
-      tf::resolve("", GetModel()->NameSpaceTF(frame_id_));
+  laser_scan_.header.frame_id = frame_id_;
 
   // Broadcast transform between the body and laser
   tf::Quaternion q;
@@ -146,7 +146,7 @@ void Laser::BeforePhysicsStep(const Timekeeper& timekeeper) {
 
   // only compute and publish when the number of subscribers is not zero, or always_publish_ is true
   if (always_publish_ || scan_publisher_.getNumSubscribers() > 0) {
-    // START_PROFILE(timekeeper, "compute laser range");
+    START_PROFILE(timekeeper, "compute laser range");
     auto start = std::chrono::steady_clock::now();
     ComputeLaserRanges();
 
@@ -154,7 +154,7 @@ void Laser::BeforePhysicsStep(const Timekeeper& timekeeper) {
         1, "Laser Plugin", "took %luus",
         std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - start).count());
 
-    // END_PROFILE(timekeeper, "compute laser range");
+    END_PROFILE(timekeeper, "compute laser range");
     laser_scan_.header.stamp = timekeeper.GetSimTime();
     scan_publisher_.publish(laser_scan_);
     publications_++;

--- a/flatland_plugins/test/bumper_test.cpp
+++ b/flatland_plugins/test/bumper_test.cpp
@@ -62,7 +62,7 @@ using namespace flatland_msgs;
 class BumperPluginTest : public ::testing::Test {
  public:
   boost::filesystem::path this_file_dir;
-  boost::filesystem::path world_yaml;
+  boost::filesystem::path world_yaml_path;
   flatland_msgs::Collisions msg1, msg2;
   World* w;
 
@@ -182,12 +182,14 @@ class BumperPluginTest : public ::testing::Test {
  * Test the bumper plugin for a given model and plugin configuration
  */
 TEST_F(BumperPluginTest, collision_test) {
-  world_yaml =
-      this_file_dir / fs::path("bumper_tests/collision_test/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("bumper_tests/collision_test/");
 
   Timekeeper timekeeper;
   timekeeper.SetMaxStepSize(0.01);
-  w = World::MakeWorld(world_yaml.string());
+  w = World::MakeWorld(world_yaml_path.string() + "world.yaml",
+                       world_yaml_path.string(),
+                       world_yaml_path.string() + "world_plugins.yaml");
+  w->LoadWorldEntities();
 
   ros::NodeHandle nh;
   ros::Subscriber sub_1, sub_2, sub_3;
@@ -284,10 +286,14 @@ TEST_F(BumperPluginTest, collision_test) {
  * Test with a invalid body specified in the exclude list
  */
 TEST_F(BumperPluginTest, invalid_A) {
-  world_yaml = this_file_dir / fs::path("bumper_tests/invalid_A/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("bumper_tests/invalid_A/");
 
   try {
-    w = World::MakeWorld(world_yaml.string());
+    w = World::MakeWorld(world_yaml_path.string() + "world.yaml",
+                         world_yaml_path.string(),
+                         world_yaml_path.string() + "world_plugins.yaml");
+    w->LoadWorldEntities();
+
     FAIL() << "Expected an exception, but none were raised";
   } catch (const PluginException& e) {
     std::cmatch match;

--- a/flatland_plugins/test/bumper_tests/collision_test/world.yaml
+++ b/flatland_plugins/test/bumper_tests/collision_test/world.yaml
@@ -1,5 +1,4 @@
-properties: {}
-layers: 
+layers:
   - name: "layer_1"
     map: "map_1.yaml"
     color: [0, 1, 0, 1]

--- a/flatland_plugins/test/bumper_tests/collision_test/world_plugins.yaml
+++ b/flatland_plugins/test/bumper_tests/collision_test/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_plugins/test/bumper_tests/invalid_A/world.yaml
+++ b/flatland_plugins/test/bumper_tests/invalid_A/world.yaml
@@ -1,5 +1,4 @@
-properties: {}
-layers: 
+layers:
   - name: "layer_1"
     map: "../collision_test/map_1.yaml"
     color: [0, 1, 0, 1]

--- a/flatland_plugins/test/bumper_tests/invalid_A/world_plugins.yaml
+++ b/flatland_plugins/test/bumper_tests/invalid_A/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_plugins/test/diff_drive_test.test
+++ b/flatland_plugins/test/diff_drive_test.test
@@ -5,5 +5,5 @@ This file is used so that rosmaster is running when the test is executed,
 in order to test publish/subscribe
 -->
 <launch>
-  <test pkg="flatland_plugins" type="diff_drive_test" test-name="diff_drive_test"/>
+  <test pkg="flatland_plugins" type="diff_drive_plugin_test" test-name="diff_drive_plugin_test"/>
 </launch>

--- a/flatland_plugins/test/laser_test.cpp
+++ b/flatland_plugins/test/laser_test.cpp
@@ -60,7 +60,7 @@ using namespace flatland_plugins;
 class LaserPluginTest : public ::testing::Test {
  public:
   boost::filesystem::path this_file_dir;
-  boost::filesystem::path world_yaml;
+  boost::filesystem::path world_yaml_path;
   sensor_msgs::LaserScan scan_front, scan_center, scan_back;
   World* w;
 
@@ -166,11 +166,14 @@ class LaserPluginTest : public ::testing::Test {
  * Test the laser plugin for a given model and plugin configuration
  */
 TEST_F(LaserPluginTest, range_test) {
-  world_yaml = this_file_dir / fs::path("laser_tests/range_test/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("laser_tests/range_test/");
 
   Timekeeper timekeeper;
   timekeeper.SetMaxStepSize(1.0);
-  w = World::MakeWorld(world_yaml.string());
+  w = World::MakeWorld(world_yaml_path.string() + "world.yaml",
+                       world_yaml_path.string(),
+                       world_yaml_path.string() + "world_plugins.yaml");
+  w->LoadWorldEntities();
 
   ros::NodeHandle nh;
   ros::Subscriber sub_1, sub_2, sub_3;
@@ -192,18 +195,18 @@ TEST_F(LaserPluginTest, range_test) {
   }
 
   // check scan returns
-  EXPECT_TRUE(ScanEq(scan_front, "r_laser_front", -M_PI / 2, M_PI / 2, M_PI / 2,
+  EXPECT_TRUE(ScanEq(scan_front, "laser_front", -M_PI / 2, M_PI / 2, M_PI / 2,
                      0.0, 0.0, 0.0, 5.0, {4.5, 4.4, 4.3}, {}));
   EXPECT_TRUE(fltcmp(p1->update_rate_, std::numeric_limits<float>::infinity()))
       << "Actual: " << p1->update_rate_;
   EXPECT_EQ(p1->body_, w->models_[0]->bodies_[0]);
 
-  EXPECT_TRUE(ScanEq(scan_center, "r_center_laser", 0, 2 * M_PI, M_PI / 2, 0.0,
+  EXPECT_TRUE(ScanEq(scan_center, "center_laser", 0, 2 * M_PI, M_PI / 2, 0.0,
                      0.0, 0.0, 5.0, {4.8, 4.7, 4.6, 4.9, 4.8}, {}));
   EXPECT_TRUE(fltcmp(p2->update_rate_, 5000)) << "Actual: " << p2->update_rate_;
   EXPECT_EQ(p2->body_, w->models_[0]->bodies_[0]);
 
-  EXPECT_TRUE(ScanEq(scan_back, "r_laser_back", 0, 2 * M_PI, M_PI / 2, 0.0, 0.0,
+  EXPECT_TRUE(ScanEq(scan_back, "laser_back", 0, 2 * M_PI, M_PI / 2, 0.0, 0.0,
                      0.0, 4, {NAN, 3.2, 3.5, NAN, NAN}, {}));
   EXPECT_TRUE(fltcmp(p3->update_rate_, 1)) << "Actual: " << p2->update_rate_;
   EXPECT_EQ(p3->body_, w->models_[0]->bodies_[0]);
@@ -285,12 +288,14 @@ TEST_F(LaserPluginTest, scan_direction_test2) {
  * Test the laser plugin for intensity configuration
  */
 TEST_F(LaserPluginTest, intensity_test) {
-  world_yaml =
-      this_file_dir / fs::path("laser_tests/intensity_test/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("laser_tests/intensity_test/");
 
   Timekeeper timekeeper;
   timekeeper.SetMaxStepSize(1.0);
-  w = World::MakeWorld(world_yaml.string());
+  w = World::MakeWorld(world_yaml_path.string() + "world.yaml",
+                       world_yaml_path.string(),
+                       world_yaml_path.string() + "world_plugins.yaml");
+  w->LoadWorldEntities();
 
   ros::NodeHandle nh;
   ros::Subscriber sub_1, sub_2, sub_3;
@@ -312,17 +317,17 @@ TEST_F(LaserPluginTest, intensity_test) {
   }
 
   // check scan returns
-  EXPECT_TRUE(ScanEq(scan_front, "r_laser_front", -M_PI / 2, M_PI / 2, M_PI / 2,
+  EXPECT_TRUE(ScanEq(scan_front, "laser_front", -M_PI / 2, M_PI / 2, M_PI / 2,
                      0.0, 0.0, 0.0, 5.0, {4.5, 4.4, 4.3}, {0, 0, 0}));
   EXPECT_TRUE(fltcmp(p1->update_rate_, std::numeric_limits<float>::infinity()))
       << "Actual: " << p1->update_rate_;
   EXPECT_EQ(p1->body_, w->models_[0]->bodies_[0]);
-  EXPECT_TRUE(ScanEq(scan_center, "r_center_laser", 0, 2 * M_PI, M_PI / 2, 0.0,
+  EXPECT_TRUE(ScanEq(scan_center, "center_laser", 0, 2 * M_PI, M_PI / 2, 0.0,
                      0.0, 0.0, 5.0, {4.8, 4.7, 4.6, 4.9, 4.8},
                      {0, 255, 0, 0, 0}));
   EXPECT_TRUE(fltcmp(p2->update_rate_, 5000)) << "Actual: " << p2->update_rate_;
   EXPECT_EQ(p2->body_, w->models_[0]->bodies_[0]);
-  EXPECT_TRUE(ScanEq(scan_back, "r_laser_back", 0, 2 * M_PI, M_PI / 2, 0.0, 0.0,
+  EXPECT_TRUE(ScanEq(scan_back, "laser_back", 0, 2 * M_PI, M_PI / 2, 0.0, 0.0,
                      0.0, 4, {NAN, 3.2, 3.5, NAN, NAN}, {0, 0, 0, 0, 0}));
   EXPECT_TRUE(fltcmp(p3->update_rate_, 1)) << "Actual: " << p2->update_rate_;
   EXPECT_EQ(p3->body_, w->models_[0]->bodies_[0]);
@@ -333,10 +338,13 @@ TEST_F(LaserPluginTest, intensity_test) {
  * configurations
  */
 TEST_F(LaserPluginTest, invalid_A) {
-  world_yaml = this_file_dir / fs::path("laser_tests/invalid_A/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("laser_tests/invalid_A/");
 
   try {
-    w = World::MakeWorld(world_yaml.string());
+    w = World::MakeWorld(world_yaml_path.string() + "world.yaml",
+                         world_yaml_path.string(),
+                         world_yaml_path.string() + "world_plugins.yaml");
+    w->LoadWorldEntities();
 
     FAIL() << "Expected an exception, but none were raised";
   } catch (const PluginException& e) {
@@ -358,10 +366,13 @@ TEST_F(LaserPluginTest, invalid_A) {
  * configurations
  */
 TEST_F(LaserPluginTest, invalid_B) {
-  world_yaml = this_file_dir / fs::path("laser_tests/invalid_B/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("laser_tests/invalid_B/");
 
   try {
-    w = World::MakeWorld(world_yaml.string());
+    w = World::MakeWorld(world_yaml_path.string() + "world.yaml",
+                         world_yaml_path.string(),
+                         world_yaml_path.string() + "world_plugins.yaml");
+    w->LoadWorldEntities();
 
     FAIL() << "Expected an exception, but none were raised";
   } catch (const PluginException& e) {

--- a/flatland_plugins/test/laser_tests/intensity_test/world.yaml
+++ b/flatland_plugins/test/laser_tests/intensity_test/world.yaml
@@ -1,5 +1,4 @@
-properties: {}
-layers: 
+layers:
   - name: "layer_1"
     map: "map_1.yaml"
     color: [0, 1, 0, 1]

--- a/flatland_plugins/test/laser_tests/intensity_test/world_plugins.yaml
+++ b/flatland_plugins/test/laser_tests/intensity_test/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_plugins/test/laser_tests/invalid_A/world.yaml
+++ b/flatland_plugins/test/laser_tests/invalid_A/world.yaml
@@ -1,5 +1,4 @@
-properties: {}
-layers: 
+layers:
   - name: "layer_1"
     map: "../range_test/map_1.yaml"
     color: [0, 1, 0, 1]

--- a/flatland_plugins/test/laser_tests/invalid_A/world_plugins.yaml
+++ b/flatland_plugins/test/laser_tests/invalid_A/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_plugins/test/laser_tests/invalid_B/world.yaml
+++ b/flatland_plugins/test/laser_tests/invalid_B/world.yaml
@@ -1,5 +1,4 @@
-properties: {}
-layers: 
+layers:
   - name: "layer_1"
     map: "../range_test/map_1.yaml"
     color: [0, 1, 0, 1]

--- a/flatland_plugins/test/laser_tests/invalid_B/world_plugins.yaml
+++ b/flatland_plugins/test/laser_tests/invalid_B/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_plugins/test/laser_tests/range_test/world.yaml
+++ b/flatland_plugins/test/laser_tests/range_test/world.yaml
@@ -1,5 +1,4 @@
-properties: {}
-layers: 
+layers:
   - name: "layer_1"
     map: "map_1.yaml"
     color: [0, 1, 0, 1]

--- a/flatland_plugins/test/laser_tests/range_test/world_plugins.yaml
+++ b/flatland_plugins/test/laser_tests/range_test/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_plugins/test/model_tf_publisher_test.cpp
+++ b/flatland_plugins/test/model_tf_publisher_test.cpp
@@ -62,7 +62,7 @@ using namespace flatland_plugins;
 class ModelTfPublisherTest : public ::testing::Test {
  public:
   boost::filesystem::path this_file_dir;
-  boost::filesystem::path world_yaml;
+  boost::filesystem::path world_yaml_path;
   World* w;
 
   void SetUp() override {
@@ -119,13 +119,16 @@ class ModelTfPublisherTest : public ::testing::Test {
  * Test the transformation for the model robot in a given plugin configuration
  */
 TEST_F(ModelTfPublisherTest, tf_publish_test_A) {
-  world_yaml =
-      this_file_dir /
-      fs::path("model_tf_publisher_tests/tf_publish_test_A/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("model_tf_publisher_tests/tf_publish_test_A/");
 
   Timekeeper timekeeper;
   timekeeper.SetMaxStepSize(1.0);
-  w = World::MakeWorld(world_yaml.string());
+  w = World::MakeWorld(world_yaml_path.string() + "world.yaml",
+                       world_yaml_path.string(),
+                       world_yaml_path.string() + "world_plugins.yaml");
+  w->LoadWorldEntities();
+
   ModelTfPublisher* p = dynamic_cast<ModelTfPublisher*>(
       w->plugin_manager_.model_plugins_[0].get());
 
@@ -193,13 +196,16 @@ TEST_F(ModelTfPublisherTest, tf_publish_test_A) {
  * Test the transformation for the model robot in another plugin configuration
  */
 TEST_F(ModelTfPublisherTest, tf_publish_test_B) {
-  world_yaml =
-      this_file_dir /
-      fs::path("model_tf_publisher_tests/tf_publish_test_B/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("model_tf_publisher_tests/tf_publish_test_B/");
 
   Timekeeper timekeeper;
   timekeeper.SetMaxStepSize(1.0);
-  w = World::MakeWorld(world_yaml.string());
+  w = World::MakeWorld(world_yaml_path.string() + "world.yaml",
+                       world_yaml_path.string(),
+                       world_yaml_path.string() + "world_plugins.yaml");
+  w->LoadWorldEntities();
+
   ModelTfPublisher* p = dynamic_cast<ModelTfPublisher*>(
       w->plugin_manager_.model_plugins_[0].get());
 
@@ -256,11 +262,14 @@ TEST_F(ModelTfPublisherTest, tf_publish_test_B) {
  * to a nonexistent reference body
  */
 TEST_F(ModelTfPublisherTest, invalid_A) {
-  world_yaml =
-      this_file_dir / fs::path("model_tf_publisher_tests/invalid_A/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("model_tf_publisher_tests/invalid_A/");
 
   try {
-    w = World::MakeWorld(world_yaml.string());
+    w = World::MakeWorld(world_yaml_path.string() + "world.yaml",
+                         world_yaml_path.string(),
+                         world_yaml_path.string() + "world_plugins.yaml");
+    w->LoadWorldEntities();
 
     FAIL() << "Expected an exception, but none were raised";
   } catch (const PluginException& e) {
@@ -282,11 +291,14 @@ TEST_F(ModelTfPublisherTest, invalid_A) {
  * to a nonexistent body specified in the exclude list
  */
 TEST_F(ModelTfPublisherTest, invalid_B) {
-  world_yaml =
-      this_file_dir / fs::path("model_tf_publisher_tests/invalid_B/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("model_tf_publisher_tests/invalid_B/");
 
   try {
-    w = World::MakeWorld(world_yaml.string());
+    w = World::MakeWorld(world_yaml_path.string() + "world.yaml",
+                         world_yaml_path.string(),
+                         world_yaml_path.string() + "world_plugins.yaml");
+    w->LoadWorldEntities();
 
     FAIL() << "Expected an exception, but none were raised";
   } catch (const PluginException& e) {

--- a/flatland_plugins/test/model_tf_publisher_tests/invalid_A/world.yaml
+++ b/flatland_plugins/test/model_tf_publisher_tests/invalid_A/world.yaml
@@ -1,5 +1,4 @@
-properties: {}
-layers: 
+layers:
   - name: "layer_1"
     map: "../tf_publish_test_A/map_1.yaml"
     color: [0, 1, 0, 1]

--- a/flatland_plugins/test/model_tf_publisher_tests/invalid_A/world_plugins.yaml
+++ b/flatland_plugins/test/model_tf_publisher_tests/invalid_A/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_plugins/test/model_tf_publisher_tests/invalid_B/world.yaml
+++ b/flatland_plugins/test/model_tf_publisher_tests/invalid_B/world.yaml
@@ -1,5 +1,4 @@
-properties: {}
-layers: 
+layers:
   - name: "layer_1"
     map: "../tf_publish_test_A/map_1.yaml"
     color: [0, 1, 0, 1]

--- a/flatland_plugins/test/model_tf_publisher_tests/invalid_B/world_plugins.yaml
+++ b/flatland_plugins/test/model_tf_publisher_tests/invalid_B/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_plugins/test/model_tf_publisher_tests/tf_publish_test_A/world.yaml
+++ b/flatland_plugins/test/model_tf_publisher_tests/tf_publish_test_A/world.yaml
@@ -1,5 +1,4 @@
-properties: {}
-layers: 
+layers:
   - name: "layer_1"
     map: "map_1.yaml"
     color: [0, 1, 0, 1]

--- a/flatland_plugins/test/model_tf_publisher_tests/tf_publish_test_A/world_plugins.yaml
+++ b/flatland_plugins/test/model_tf_publisher_tests/tf_publish_test_A/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_plugins/test/model_tf_publisher_tests/tf_publish_test_B/world.yaml
+++ b/flatland_plugins/test/model_tf_publisher_tests/tf_publish_test_B/world.yaml
@@ -1,5 +1,4 @@
-properties: {}
-layers: 
+layers:
   - name: "layer_1"
     map: "../tf_publish_test_A/map_1.yaml"
     color: [0, 1, 0, 1]

--- a/flatland_plugins/test/model_tf_publisher_tests/tf_publish_test_B/world_plugins.yaml
+++ b/flatland_plugins/test/model_tf_publisher_tests/tf_publish_test_B/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_plugins/test/tween_test.cpp
+++ b/flatland_plugins/test/tween_test.cpp
@@ -58,7 +58,7 @@ using namespace flatland_plugins;
 class TweenPluginTest : public ::testing::Test {
  public:
   boost::filesystem::path this_file_dir;
-  boost::filesystem::path world_yaml;
+  boost::filesystem::path world_yaml_path;
 
   void SetUp() override {
     this_file_dir = boost::filesystem::path(__FILE__).parent_path();
@@ -82,11 +82,14 @@ class TweenPluginTest : public ::testing::Test {
  * Test the tween plugin handles oneshot
  */
 TEST_F(TweenPluginTest, once_test) {
-  world_yaml = this_file_dir / fs::path("tween_tests/once.world.yaml");
+  world_yaml_path = this_file_dir / fs::path("tween_tests/");
 
   Timekeeper timekeeper;
   timekeeper.SetMaxStepSize(0.5);
-  World* w = World::MakeWorld(world_yaml.string());
+  World* w = World::MakeWorld(
+      world_yaml_path.string() + "once.world.yaml", world_yaml_path.string(),
+      world_yaml_path.string() + "once.world_plugins.yaml");
+  w->LoadWorldEntities();
 
   Tween* tween =
       dynamic_cast<Tween*>(w->plugin_manager_.model_plugins_[0].get());
@@ -116,11 +119,14 @@ TEST_F(TweenPluginTest, once_test) {
  * Test that the tween plugin yoyos
  */
 TEST_F(TweenPluginTest, yoyo_test) {
-  world_yaml = this_file_dir / fs::path("tween_tests/yoyo.world.yaml");
+  world_yaml_path = this_file_dir / fs::path("tween_tests/");
 
   Timekeeper timekeeper;
   timekeeper.SetMaxStepSize(0.5);
-  World* w = World::MakeWorld(world_yaml.string());
+  World* w = World::MakeWorld(
+      world_yaml_path.string() + "yoyo.world.yaml", world_yaml_path.string(),
+      world_yaml_path.string() + "yoyo.world_plugins.yaml");
+  w->LoadWorldEntities();
 
   Tween* tween =
       dynamic_cast<Tween*>(w->plugin_manager_.model_plugins_[0].get());
@@ -159,11 +165,14 @@ TEST_F(TweenPluginTest, yoyo_test) {
  * Test that the tween plugin loops
  */
 TEST_F(TweenPluginTest, loop_test) {
-  world_yaml = this_file_dir / fs::path("tween_tests/loop.world.yaml");
+  world_yaml_path = this_file_dir / fs::path("tween_tests/");
 
   Timekeeper timekeeper;
   timekeeper.SetMaxStepSize(0.5);
-  World* w = World::MakeWorld(world_yaml.string());
+  World* w = World::MakeWorld(
+      world_yaml_path.string() + "loop.world.yaml", world_yaml_path.string(),
+      world_yaml_path.string() + "loop.world_plugins.yaml");
+  w->LoadWorldEntities();
 
   Tween* tween =
       dynamic_cast<Tween*>(w->plugin_manager_.model_plugins_[0].get());

--- a/flatland_plugins/test/tween_tests/loop.world.yaml
+++ b/flatland_plugins/test/tween_tests/loop.world.yaml
@@ -1,5 +1,4 @@
-properties: {}
-layers: 
+layers:
   - name: "layer_1"
     map: "map_1.yaml"
     color: [0, 1, 0, 1]

--- a/flatland_plugins/test/tween_tests/loop.world_plugins.yaml
+++ b/flatland_plugins/test/tween_tests/loop.world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_plugins/test/tween_tests/once.world.yaml
+++ b/flatland_plugins/test/tween_tests/once.world.yaml
@@ -1,5 +1,4 @@
-properties: {}
-layers: 
+layers:
   - name: "layer_1"
     map: "map_1.yaml"
     color: [0, 1, 0, 1]

--- a/flatland_plugins/test/tween_tests/once.world_plugins.yaml
+++ b/flatland_plugins/test/tween_tests/once.world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_plugins/test/tween_tests/yoyo.world.yaml
+++ b/flatland_plugins/test/tween_tests/yoyo.world.yaml
@@ -1,5 +1,4 @@
-properties: {}
-layers: 
+layers:
   - name: "layer_1"
     map: "map_1.yaml"
     color: [0, 1, 0, 1]

--- a/flatland_plugins/test/tween_tests/yoyo.world_plugins.yaml
+++ b/flatland_plugins/test/tween_tests/yoyo.world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_plugins/test/update_timer_test.cpp
+++ b/flatland_plugins/test/update_timer_test.cpp
@@ -77,7 +77,7 @@ class TestPlugin : public ModelPlugin {
 class UpdateTimerTest : public ::testing::Test {
  public:
   boost::filesystem::path this_file_dir;
-  boost::filesystem::path world_yaml;
+  boost::filesystem::path world_yaml_path;
   double set_rate;
   double expected_rate;
   double actual_rate;
@@ -99,8 +99,10 @@ class UpdateTimerTest : public ::testing::Test {
 
   void ExecuteRateTest() {
     Timekeeper timekeeper;
-    w = World::MakeWorld(world_yaml.string());
-
+    w = World::MakeWorld(world_yaml_path.string() + "world.yaml",
+                         world_yaml_path.string(),
+                         world_yaml_path.string() + "world_plugins.yaml");
+    w->LoadWorldEntities();
     // artificially load a plugin
     boost::shared_ptr<TestPlugin> p(new TestPlugin());
     p->Initialize("TestPlugin", "test_plugin", w->models_[0], YAML::Node());
@@ -128,7 +130,7 @@ class UpdateTimerTest : public ::testing::Test {
  * Test update rate at real time factor > 1
  */
 TEST_F(UpdateTimerTest, rate_test_A) {
-  world_yaml = this_file_dir / fs::path("update_timer_test/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("update_timer_test/");
   set_rate = 141.56;
   expected_rate = set_rate;
   sim_test_time = 2.0;
@@ -146,7 +148,7 @@ TEST_F(UpdateTimerTest, rate_test_A) {
  * Test update rate at real time factor < 1
  */
 TEST_F(UpdateTimerTest, rate_test_B) {
-  world_yaml = this_file_dir / fs::path("update_timer_test/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("update_timer_test/");
   set_rate = 564.56;
   expected_rate = set_rate;
   sim_test_time = 1.0;
@@ -164,7 +166,7 @@ TEST_F(UpdateTimerTest, rate_test_B) {
  * Test update rate at real time factor >> 1
  */
 TEST_F(UpdateTimerTest, rate_test_C) {
-  world_yaml = this_file_dir / fs::path("update_timer_test/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("update_timer_test/");
   set_rate = 47.4;
   expected_rate = set_rate;
   sim_test_time = 2;
@@ -182,7 +184,7 @@ TEST_F(UpdateTimerTest, rate_test_C) {
  * Test update rate at update rate = inf, which will update as fast as possible
  */
 TEST_F(UpdateTimerTest, rate_test_D) {
-  world_yaml = this_file_dir / fs::path("update_timer_test/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("update_timer_test/");
   set_rate = std::numeric_limits<double>::infinity();
   expected_rate = 100.0;
   sim_test_time = 2;
@@ -200,7 +202,7 @@ TEST_F(UpdateTimerTest, rate_test_D) {
  * Test update rate at update rate = 0, which will never update
  */
 TEST_F(UpdateTimerTest, rate_test_E) {
-  world_yaml = this_file_dir / fs::path("update_timer_test/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("update_timer_test/");
   set_rate = 0;
   expected_rate = 0;
   sim_test_time = 2;

--- a/flatland_plugins/test/update_timer_test/world.yaml
+++ b/flatland_plugins/test/update_timer_test/world.yaml
@@ -1,5 +1,4 @@
-properties: {}
-layers: 
+layers:
   - name: "layer_1"
     map: "map_1.yaml"
     color: [0, 1, 0, 1]

--- a/flatland_plugins/test/update_timer_test/world_plugins.yaml
+++ b/flatland_plugins/test/update_timer_test/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/CMakeLists.txt
+++ b/flatland_server/CMakeLists.txt
@@ -106,7 +106,7 @@ add_library(flatland_lib
   src/dummy_model_plugin.cpp 
   src/dummy_world_plugin.cpp
   src/yaml_preprocessor.cpp
-)
+  src/message_server.cpp)
 
 add_dependencies(flatland_lib ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(flatland_lib

--- a/flatland_server/include/flatland_server/body.h
+++ b/flatland_server/include/flatland_server/body.h
@@ -65,6 +65,7 @@ class Body {
   b2Body *physics_body_;   ///< Box2D physics body
   Color color_;            ///< color, for visualization
   YAML::Node properties_;  ///< Properties document for plugins to use
+  Pose parent_transform_;  ///< Transform relative to parent
 
   /**
    * @brief constructor for body, takes in all the required parameters
@@ -120,6 +121,11 @@ class Body {
    * @brief Set of the color of the body
    */
   void SetColor(const Color &color);
+
+  /**
+   * @brief Get the parent transform
+   */
+  const Pose &GetParentTransform() const;
 
   /**
    * Destructor for the body

--- a/flatland_server/include/flatland_server/collision_filter_registry.h
+++ b/flatland_server/include/flatland_server/collision_filter_registry.h
@@ -116,6 +116,11 @@ class CollisionFilterRegistry {
   std::vector<std::string> GetAllLayers() const;
 
   /**
+ * @brief Clear all registered layers
+ */
+  void ClearAllLayers();
+
+  /**
    * @brief Get number of layers
    * @return number of layers
    */

--- a/flatland_server/include/flatland_server/exceptions.h
+++ b/flatland_server/include/flatland_server/exceptions.h
@@ -101,7 +101,8 @@ class YAMLException : public Exception {
    * exception message using just a message
    * @param[in] msg Exception message
    */
-  YAMLException(const std::string &msg) : Exception("Flatland YAML: " + msg) {}
+  explicit YAMLException(const std::string &msg)
+      : Exception("Flatland YAML: " + msg) {}
 
  private:
   /**
@@ -123,7 +124,7 @@ class YAMLException : public Exception {
              << yaml_cpp_mark.column + 1;
     }
 
-    if (yaml_cpp_msg.size() > 0) {
+    if (!yaml_cpp_msg.empty()) {
       output << ", " << yaml_cpp_msg;
     }
 

--- a/flatland_server/include/flatland_server/interactive_marker_manager.h
+++ b/flatland_server/include/flatland_server/interactive_marker_manager.h
@@ -1,5 +1,5 @@
-#ifndef INTERACTIVEMARKERMANAGER_H
-#define INTERACTIVEMARKERMANAGER_H
+#ifndef FLATLAND_SERVER_INTERACTIVE_MARKER_MANAGER_H
+#define FLATLAND_SERVER_INTERACTIVE_MARKER_MANAGER_H
 
 #include <flatland_server/geometry.h>
 #include <flatland_server/model.h>

--- a/flatland_server/include/flatland_server/layer.h
+++ b/flatland_server/include/flatland_server/layer.h
@@ -70,6 +70,16 @@ class Layer : public Entity {
   CollisionFilterRegistry *cfr_;  ///< collision filter registry
   std::string viz_name_;          ///< for visualization
 
+  struct MapDescription {
+    std::string path_;
+    double resolution_;
+    MapDescription() {}
+    MapDescription(const std::string &path, const double resolution)
+        : path_(path), resolution_(resolution) {}
+  };
+
+  const MapDescription map_description_;
+
   /**
    * @brief Constructor for the Layer class for initialization using a image
    * map file
@@ -87,8 +97,9 @@ class Layer : public Entity {
    */
   Layer(b2World *physics_world, CollisionFilterRegistry *cfr,
         const std::vector<std::string> &names, const Color &color,
-        const Pose &origin, const cv::Mat &bitmap, double occupied_thresh,
-        double resolution, const YAML::Node &properties);
+        const Pose &origin, const std::string &map_path, const cv::Mat &bitmap,
+        double occupied_thresh, double resolution,
+        const YAML::Node &properties);
 
   /**
    * @brief Constructor for the Layer class for initialization using line

--- a/flatland_server/include/flatland_server/message_server.h
+++ b/flatland_server/include/flatland_server/message_server.h
@@ -1,0 +1,113 @@
+#ifndef FLATLAND_SERVER_MESSAGE_SERVER_H
+#define FLATLAND_SERVER_MESSAGE_SERVER_H
+
+#include <unordered_map>
+#include <vector>
+
+#include <ros/ros.h>
+
+namespace flatland_server {
+
+template <class T>
+class Subscriber;
+template <class T>
+class Publisher;
+class MessageServer;
+class MessageTopicBase {};
+
+template <class T>
+class MessageTopic : public MessageTopicBase {
+ public:
+  std::vector<Subscriber<T>> subscribers_;
+};
+
+template <class T>
+class Subscriber {
+ public:
+  Subscriber() = default;
+
+  explicit Subscriber(MessageTopic<T>* topic,
+                      const std::function<void(const T&)>& callback_function)
+      : topic_(topic), callback_function_(callback_function) {}
+
+ private:
+  MessageTopic<T>* topic_;
+  std::function<void(const T&)> callback_function_;
+
+  friend class Publisher<T>;
+};
+
+template <class T>
+class Publisher {
+ public:
+  Publisher() = default;
+  explicit Publisher(MessageTopic<T>* topic) : topic_(topic) {}
+
+  void publish(const T&);
+
+ private:
+  MessageTopic<T>* topic_;
+};
+
+class MessageServer {
+ private:
+  std::unordered_map<std::string, std::unique_ptr<MessageTopicBase>> topics_;
+
+  template <class T>
+  MessageTopic<T>* get_message_topic(const std::string& name);
+
+ public:
+  template <class T>
+  Subscriber<T> subscribe(
+      const std::string& name,
+      const std::function<void(const T&)>& callback_function);
+
+  template <class T>
+  Publisher<T> advertise(const std::string& name);
+};
+
+///
+/// Start of Implementation section
+///
+
+template <class T>
+MessageTopic<T>* MessageServer::get_message_topic(const std::string& name) {
+  auto msg_topic = topics_.find(name);
+  if (msg_topic == topics_.end()) {
+    msg_topic = topics_
+                    .emplace(name, std::unique_ptr<MessageTopic<T>>(
+                                       new flatland_server::MessageTopic<T>()))
+                    .first;
+  }
+  return static_cast<MessageTopic<T>*>((msg_topic->second).get());
+}
+
+template <class T>
+Subscriber<T> MessageServer::subscribe(
+    const std::string& name,
+    const std::function<void(const T&)>& callback_function) {
+  flatland_server::MessageTopic<T>* topic = get_message_topic<T>(name);
+
+  // TODO - Make it so that when the copied subscriber gets deleted, it will be
+  // removed from the topic list
+  // Not bothering to fix it now because, currently deletion of subscribers has
+  // not been fully implemented
+  topic->subscribers_.emplace_back(topic, callback_function);
+  return topic->subscribers_.back();
+}
+
+template <class T>
+Publisher<T> MessageServer::advertise(const std::string& name) {
+  flatland_server::MessageTopic<T>* topic = get_message_topic<T>(name);
+  return Publisher<T>(topic);
+}
+
+template <class T>
+void Publisher<T>::publish(const T& t) {
+  for (const Subscriber<T>& subscriber : topic_->subscribers_) {
+    subscriber.callback_function_(t);
+  }
+}
+}
+
+#endif  // FLATLAND_SERVER_MESSAGE_H

--- a/flatland_server/include/flatland_server/model.h
+++ b/flatland_server/include/flatland_server/model.h
@@ -50,7 +50,9 @@
 #include <flatland_server/collision_filter_registry.h>
 #include <flatland_server/entity.h>
 #include <flatland_server/joint.h>
+#include <flatland_server/message_server.h>
 #include <flatland_server/model_body.h>
+#include <flatland_server/model_plugin.h>
 #include <flatland_server/yaml_reader.h>
 #include <yaml-cpp/yaml.h>
 #include <boost/filesystem.hpp>
@@ -58,13 +60,18 @@
 namespace flatland_server {
 
 class ModelBody;
+class ModelPlugin;
 class Joint;
+class World;
 
 /**
  * This class defines a Model. It can be used to repsent any object in the
  * environment such robots, chairs, deskes etc.
  */
 class Model : public Entity {
+ private:
+  flatland_server::World *world;
+
  public:
   std::string namespace_;            ///< namespace of the model
   std::vector<ModelBody *> bodies_;  ///< list of bodies in the model
@@ -72,16 +79,16 @@ class Model : public Entity {
   YamlReader plugins_reader_;        ///< for storing plugins when paring YAML
   CollisionFilterRegistry *cfr_;     ///< Collision filter registry
   std::string viz_name_;             ///< used for visualization
-
-  /**
-   * @brief Constructor for the model
-   * @param[in] physics_world Box2D physics world
-   * @param[in] cfr Collision filter registry
-   * @param[in] name Name of the model
-   */
+                                     /**
+                                      * @brief Constructor for the model
+                                      * @param[in] physics_world Box2D physics world
+                                      * @param[in] cfr Collision filter registry
+                                      * @param[in] name Name of the model
+                                      */
+  Model(World *world, b2World *physics_world, CollisionFilterRegistry *cfr,
+        const std::string &ns, const std::string &name);
   Model(b2World *physics_world, CollisionFilterRegistry *cfr,
         const std::string &ns, const std::string &name);
-
   /**
    * @brief Destructor for the layer class
    */
@@ -111,6 +118,25 @@ class Model : public Entity {
    * @return pointer to the body, nullptr indicates body cannot be found
    */
   ModelBody *GetBody(const std::string &name);
+
+  /**
+ * @brief Get a body in the model using its name
+ * @param[in] name Name of the body
+ * @return pointer to the body, nullptr indicates body cannot be found
+ */
+  ModelPlugin *GetPlugin(const std::string &name) const;
+
+  /**
+   * @brief Returns the
+   * @return pointer to the world, nullptr indicates world cannot be found
+   */
+  World &GetWorld() const;
+
+  /**
+    * @brief Returns the
+    * @return pointer to the world, nullptr indicates world cannot be found
+    */
+  MessageServer &GetMessageServer() const;
 
   /**
    * @brief Get a body in the model using its name
@@ -190,7 +216,8 @@ class Model : public Entity {
    * @param[in] name Name of the model
    * @return A new model
    */
-  static Model *MakeModel(b2World *physics_world, CollisionFilterRegistry *cfr,
+  static Model *MakeModel(World *world, b2World *physics_world,
+                          CollisionFilterRegistry *cfr,
                           const std::string &model_yaml_path,
                           const std::string &ns, const std::string &name);
 };

--- a/flatland_server/include/flatland_server/model_plugin.h
+++ b/flatland_server/include/flatland_server/model_plugin.h
@@ -71,7 +71,7 @@ class ModelPlugin : public FlatlandPlugin {
   /**
    * @brief Get model
    */
-  Model *GetModel();
+  Model *GetModel() const;
 
   /**
    * @brief The method to initialize the ModelPlugin, required since Pluginlib

--- a/flatland_server/include/flatland_server/plugin_manager.h
+++ b/flatland_server/include/flatland_server/plugin_manager.h
@@ -60,6 +60,7 @@ namespace flatland_server {
 
 // forward declaration
 class World;
+class ModelPlugin;
 
 class PluginManager {
  public:

--- a/flatland_server/include/flatland_server/profiler.h
+++ b/flatland_server/include/flatland_server/profiler.h
@@ -1,0 +1,94 @@
+#ifndef FLATLAND_PROFILER_H
+#define FLATLAND_PROFILER_H
+
+#define PROFILER_OUTPUT_PATH "/tmp/flatland_profile_output.log"
+
+// Define the preprocessor macro PROFILE_ON to activate profiling
+#ifdef PROFILER_ON
+#define START_PROFILE(timekeeper, name) timekeeper.profiler_.get(name).start()
+#define END_PROFILE(timekeeper, name) timekeeper.profiler_.get(name).end()
+#define PRINT_ALL_PROFILES(timekeeper) timekeeper.profiler_.print()
+#else
+#define START_PROFILE(timekeeper, name)
+#define END_PROFILE(timekeeper, name)
+#define PRINT_ALL_PROFILES(timekeeper)
+#endif
+
+#include <cassert>
+#include <chrono>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <unordered_map>
+
+namespace flatland_server {
+
+class Profile {
+ public:
+  Profile()
+      : lapse_count_(0),
+        started_(false),
+        start_time_(std::chrono::high_resolution_clock::now()),
+        total_duration_(std::chrono::high_resolution_clock::duration::zero()) {}
+
+  void start() {
+    started_ = true;
+    start_time_ = std::chrono::high_resolution_clock::now();
+  }
+
+  void end() {
+    assert(started_);
+    lapse_count_++;
+    total_duration_ += std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::high_resolution_clock::now() - start_time_);
+  }
+
+  int getLapseCount() const { return lapse_count_; }
+
+  int64_t getTotalDuration() const {
+    return std::chrono::duration_cast<std::chrono::microseconds>(
+               total_duration_)
+        .count();
+  }
+
+ private:
+  int lapse_count_;
+  bool started_;
+  std::chrono::high_resolution_clock::time_point start_time_;
+  std::chrono::high_resolution_clock::duration total_duration_;
+};
+
+class Profiler {
+ public:
+  Profile& get(const std::string& profile_name) {
+    return profiles_[profile_name];
+  }
+
+  void print() {
+    std::ofstream out(PROFILER_OUTPUT_PATH);
+
+    out << std::left << std::setw(60) << "Profile" << std::left << std::setw(20)
+        << "Lapse Count" << std::left << std::setw(20) << "Total Duration (us)"
+        << std::left << std::setw(20) << "Average Duration (us)" << std::endl;
+
+    for (const auto& prof : profiles_) {
+      out << std::left << std::setw(60) << prof.first << std::left
+          << std::setw(20) << prof.second.getLapseCount() << std::left
+          << std::setw(20) << prof.second.getTotalDuration() << std::left
+          << std::setw(20) << std::setprecision(10)
+          << ((prof.second.getLapseCount() == 0)
+                  ? 0
+                  : (prof.second.getTotalDuration() /
+                     prof.second.getLapseCount()))
+          << std::endl;
+    }
+    out.close();
+  }
+
+ private:
+  std::unordered_map<std::string, Profile> profiles_;
+};
+
+}  // namespace flatland_server
+
+#endif  // FLATLAND_PROFILER_H

--- a/flatland_server/include/flatland_server/service_manager.h
+++ b/flatland_server/include/flatland_server/service_manager.h
@@ -44,6 +44,9 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifndef FLATLAND_PLUGIN_SERVICE_MANAGER_H
+#define FLATLAND_PLUGIN_SERVICE_MANAGER_H
+
 #include <flatland_msgs/DeleteModel.h>
 #include <flatland_msgs/MoveModel.h>
 #include <flatland_msgs/SpawnModel.h>
@@ -51,9 +54,6 @@
 #include <flatland_server/world.h>
 #include <ros/ros.h>
 #include <std_srvs/Empty.h>
-
-#ifndef FLATLAND_PLUGIN_SERVICE_MANAGER_H
-#define FLATLAND_PLUGIN_SERVICE_MANAGER_H
 
 namespace flatland_server {
 

--- a/flatland_server/include/flatland_server/simulation_manager.h
+++ b/flatland_server/include/flatland_server/simulation_manager.h
@@ -49,21 +49,29 @@
 
 #include <Box2D/Box2D.h>
 #include <flatland_server/debug_visualization.h>
+#include <flatland_server/service_manager.h>
 #include <flatland_server/timekeeper.h>
 #include <flatland_server/world.h>
 #include <string>
 
 namespace flatland_server {
 
+class ServiceManager;
 class SimulationManager {
  public:
-  bool run_simulator_;           ///<  While true, keep running the sim loop
-  World *world_;                 ///< Simulation world
-  double update_rate_;           ///< sim loop rate
-  double step_size_;             ///< step size
-  bool show_viz_;                ///< flag to determine if to show visualization
-  double viz_pub_rate_;          ///< rate to publish visualization
+  bool run_simulator_;   ///<  While true, keep running the sim loop
+  World* world_;         ///< Simulation world
+  double update_rate_;   ///< sim loop rate
+  double step_size_;     ///< step size
+  bool show_viz_;        ///< flag to determine if to show visualization
+  double viz_pub_rate_;  ///< rate to publish visualization
   std::string world_yaml_file_;  ///< path to the world file
+  std::string models_path_;
+  std::string world_plugins_path_;
+
+  ros::NodeHandle nh_;
+  std::unique_ptr<flatland_server::ServiceManager> service_manager_;
+
   Timekeeper timekeeper_;        ///< Timekeeper manager
   uint64_t iterations_ = 0;      ///< Main loop iteration count (for debugging/profiling)
 
@@ -76,8 +84,9 @@ class SimulationManager {
    * @param[in] viz_pub_rate rate to publish visualization
    * behaving ones
    */
-  SimulationManager(std::string world_yaml_file, double update_rate,
-                    double step_size, bool show_viz, double viz_pub_rate);
+  SimulationManager(std::string world_yaml_file, std::string models_path,
+                    std::string world_plugins_path, double update_rate, double step_size, bool show_viz,
+                    double viz_pub_rate);
 
   /**
    * This method contains the loop that runs the simulation

--- a/flatland_server/include/flatland_server/timekeeper.h
+++ b/flatland_server/include/flatland_server/timekeeper.h
@@ -47,6 +47,7 @@
 #ifndef FLATLAND_SERVER_TIME_KEEPER_H
 #define FLATLAND_SERVER_TIME_KEEPER_H
 
+#include <flatland_server/profiler.h>
 #include <ros/ros.h>
 #include <ros/time.h>
 
@@ -59,6 +60,7 @@ class Timekeeper {
   ros::Time time_;                 ///< simulation time
   double max_step_size_;           ///< maximum step size
   const std::string clock_topic_;  ///< the name of the clock topic
+  mutable Profiler profiler_;
 
   /**
    * @brief constructor

--- a/flatland_server/include/flatland_server/types.h
+++ b/flatland_server/include/flatland_server/types.h
@@ -95,7 +95,7 @@ struct Pose {
   Pose(const std::array<double, 3> &p) {
     this->x = p[0];
     this->y = p[1];
-    this->theta = p[3];
+    this->theta = p[2];
   }
 
   Pose() : x(0), y(0), theta(0) {}

--- a/flatland_server/include/flatland_server/world.h
+++ b/flatland_server/include/flatland_server/world.h
@@ -51,10 +51,13 @@
 #include <flatland_server/collision_filter_registry.h>
 #include <flatland_server/interactive_marker_manager.h>
 #include <flatland_server/layer.h>
+#include <flatland_server/message_server.h>
 #include <flatland_server/model.h>
 #include <flatland_server/plugin_manager.h>
 #include <flatland_server/timekeeper.h>
+
 #include <map>
+#include <queue>
 #include <string>
 #include <string>
 #include <vector>
@@ -66,6 +69,8 @@ namespace flatland_server {
  * that can represent environments at multiple levels, and models which are
  * can be robots or obstacles.
  */
+class InteractiveMarkerManager;
+
 class World : public b2ContactListener {
  public:
   boost::filesystem::path world_yaml_dir_;  ///<directory containing world file
@@ -83,6 +88,11 @@ class World : public b2ContactListener {
       int_marker_manager_;  ///< for dynamically moving models from Rviz
   int physics_position_iterations_;  ///< Box2D solver param
   int physics_velocity_iterations_;  ///< Box2D solver param
+
+  MessageServer message_server;
+
+  std::string yaml_path_;
+  std::string models_path_;
 
   /**
    * @brief Constructor for the world class. All data required for
@@ -164,6 +174,13 @@ class World : public b2ContactListener {
   void DeleteModel(const std::string &name);
 
   /**
+ * @brief get model with a given name
+ * @param[in] name The name of the model you are looking for
+ * @param[out] Model* The model that you find
+ */
+  const Model *GetModel(const std::string &name);
+
+  /**
    * @brief move model with a given name
    * @param[in] name The name of the model to move
    * @param[in] pose The desired new pose of the model
@@ -195,15 +212,24 @@ class World : public b2ContactListener {
    * @brief factory method to create a instance of the world class. Cleans all
    * the inputs before instantiation of the class. TThrows YAMLException.
    * @param[in] yaml_path Path to the world yaml file
+   * @param[in] models_path Path to the world yaml file
+   * @param[in] world_plugins_path Path to the world yaml file
    * @return pointer to a new world
    */
-  static World *MakeWorld(const std::string &yaml_path);
+  static World *MakeWorld(const std::string &yaml_path,
+                          const std::string &models_path,
+                          const std::string &world_plugins_path);
 
   /**
-   * @brief Publish debug visualizations for everything
-   * @param[in] update_layers since layers are pretty much static, this
-   * parameter is used to skip updating layers
+   * @brief Loads the layers and objects in the world
    */
+  void LoadWorldEntities();
+
+  /**
+ * @brief Publish debug visualizations for everything
+ * @param[in] update_layers since layers are pretty much static, this
+ * parameter is used to skip updating layers
+ */
   void DebugVisualize(bool update_layers = true);
 };
 };      // namespace flatland_server

--- a/flatland_server/launch/server.launch
+++ b/flatland_server/launch/server.launch
@@ -9,9 +9,7 @@
   <arg name="step_size" default="0.005"/>
   <arg name="show_viz" default="true"/>
   <arg name="viz_pub_rate" default="30.0"/>
-  <arg name="use_rviz" default="false"/>  
-
-  <env name="ROSCONSOLE_FORMAT" value="[${severity} ${time} ${logger}]: ${message}" />
+  <arg name="use_rviz" default="false"/>
 
   <param name="use_sim_time" value="true"/>  
 
@@ -23,7 +21,6 @@
     <param name="step_size" value="$(arg step_size)" />
     <param name="show_viz" value="$(arg show_viz)" />
     <param name="viz_pub_rate" value="$(arg viz_pub_rate)" />
-    
   </node>
 
 <group if="$(arg show_viz)">

--- a/flatland_server/src/body.cpp
+++ b/flatland_server/src/body.cpp
@@ -61,6 +61,7 @@ Body::Body(b2World *physics_world, Entity *entity, const std::string &name,
   body_def.linearDamping = linear_damping;
   body_def.angularDamping = angular_damping;
 
+  parent_transform_ = pose;
   physics_body_ = physics_world->CreateBody(&body_def);
   physics_body_->SetUserData(this);
 }
@@ -87,6 +88,8 @@ const std::string &Body::GetName() const { return name_; }
 b2Body *Body::GetPhysicsBody() { return physics_body_; }
 
 const Color &Body::GetColor() const { return color_; }
+
+const Pose &Body::GetParentTransform() const { return parent_transform_; }
 
 void Body::SetColor(const Color &color) { color_ = color; }
 

--- a/flatland_server/src/collision_filter_registry.cpp
+++ b/flatland_server/src/collision_filter_registry.cpp
@@ -117,6 +117,8 @@ std::vector<std::string> CollisionFilterRegistry::GetAllLayers() const {
   return layer_names;
 }
 
+void CollisionFilterRegistry::ClearAllLayers() { layer_id_table_.clear(); }
+
 int CollisionFilterRegistry::LayersCount() const {
   return layer_id_table_.size();
 }

--- a/flatland_server/src/debug_visualization.cpp
+++ b/flatland_server/src/debug_visualization.cpp
@@ -156,18 +156,26 @@ void DebugVisualization::BodyToMarkers(visualization_msgs::MarkerArray& markers,
 
       } break;
 
-      case b2Shape::e_polygon: {  // Convert b2Polygon -> LINE_STRIP
+      case b2Shape::e_polygon: {  // Currently only
         b2PolygonShape* poly = (b2PolygonShape*)fixture->GetShape();
-        marker.type = marker.LINE_STRIP;
-        marker.scale.x = 0.03;  // 3cm wide lines
+        marker.type = marker.TRIANGLE_LIST;
 
-        for (int i = 0; i < poly->m_count; i++) {
-          geometry_msgs::Point p;
-          p.x = poly->m_vertices[i].x;
-          p.y = poly->m_vertices[i].y;
-          marker.points.push_back(p);
+        geometry_msgs::Point p1;
+        p1.x = poly->m_vertices[0].x;
+        p1.y = poly->m_vertices[0].y;
+
+        for (int i = 1; i < poly->m_count - 1; i++) {
+          geometry_msgs::Point p2;
+          p2.x = poly->m_vertices[i].x;
+          p2.y = poly->m_vertices[i].y;
+          geometry_msgs::Point p3;
+          p3.x = poly->m_vertices[i + 1].x;
+          p3.y = poly->m_vertices[i + 1].y;
+
+          marker.points.push_back(p1);
+          marker.points.push_back(p2);
+          marker.points.push_back(p3);
         }
-        marker.points.push_back(marker.points[0]);  // Close the shape
 
       } break;
 

--- a/flatland_server/src/flatland_server_node.cpp
+++ b/flatland_server/src/flatland_server_node.cpp
@@ -79,9 +79,23 @@ int main(int argc, char **argv) {
   ros::NodeHandle node_handle("~");
 
   // Load parameters
-  std::string world_path;  // The file path to the world.yaml file
+  std::string world_path = "";  // The file path to the world.yaml file
   if (!node_handle.getParam("world_path", world_path)) {
     ROS_FATAL_NAMED("Node", "No world_path parameter given!");
+    ros::shutdown();
+    return 1;
+  }
+
+  std::string models_path;
+  if (!node_handle.getParam("models_path", models_path)) {
+    ROS_FATAL_NAMED("Node", "No models_path parameter given!");
+    ros::shutdown();
+    return 1;
+  }
+
+  std::string world_plugins_path;
+  if (!node_handle.getParam("world_plugins_path", world_plugins_path)) {
+    ROS_FATAL_NAMED("Node", "No world_plugins_path parameter given!");
     ros::shutdown();
     return 1;
   }
@@ -100,7 +114,8 @@ int main(int argc, char **argv) {
 
   // Create simulation manager object
   simulation_manager = new flatland_server::SimulationManager(
-      world_path, update_rate, step_size, show_viz, viz_pub_rate);
+      world_path, models_path, world_plugins_path, update_rate,
+      step_size, show_viz, viz_pub_rate);
 
   // Register sigint shutdown handler
   signal(SIGINT, SigintHandler);

--- a/flatland_server/src/interactive_marker_manager.cpp
+++ b/flatland_server/src/interactive_marker_manager.cpp
@@ -36,7 +36,7 @@ void InteractiveMarkerManager::createInteractiveMarker(
   plane_control.interaction_mode =
       visualization_msgs::InteractiveMarkerControl::MOVE_PLANE;
   visualization_msgs::InteractiveMarkerControl rotate_control;
-  rotate_control.always_visible = true;
+  rotate_control.always_visible = false;
   rotate_control.orientation.w = 0.707;
   rotate_control.orientation.y = 0.707;
   rotate_control.name = "rotate_z";
@@ -57,7 +57,7 @@ void InteractiveMarkerManager::createInteractiveMarker(
   text_marker.color.a = 1.0;
   text_marker.pose.position.x = 0.5;
   text_marker.pose.position.y = 0.0;
-  text_marker.scale.z = 0.5;
+  text_marker.scale.z = 0.2;
   text_marker.text = model_name;
   no_control.markers.push_back(text_marker);
 
@@ -68,8 +68,8 @@ void InteractiveMarkerManager::createInteractiveMarker(
   easy_to_click_cube.color.g = 1.0;
   easy_to_click_cube.color.b = 0.0;
   easy_to_click_cube.color.a = 0.5;
-  easy_to_click_cube.scale.x = 0.5;
-  easy_to_click_cube.scale.y = 0.5;
+  easy_to_click_cube.scale.x = 0.1;
+  easy_to_click_cube.scale.y = 0.1;
   easy_to_click_cube.scale.z = 0.05;
   easy_to_click_cube.pose.position.x = 0.0;
   plane_control.markers.push_back(easy_to_click_cube);
@@ -99,7 +99,7 @@ void InteractiveMarkerManager::createInteractiveMarker(
     if (transformed_body_marker.type ==
             visualization_msgs::Marker::LINE_STRIP ||
         transformed_body_marker.type == visualization_msgs::Marker::LINE_LIST) {
-      transformed_body_marker.scale.x = 0.1;
+      transformed_body_marker.scale.x = 0.01;
     }
 
     // Add transformed body marker to interactive marker control object
@@ -220,8 +220,8 @@ void InteractiveMarkerManager::update() {
       new_pose.orientation.w = cos(0.5 * theta);
       new_pose.orientation.z = sin(0.5 * theta);
       interactive_marker_server_->setPose((*models_)[i]->GetName(), new_pose);
-      interactive_marker_server_->applyChanges();
     }
+    interactive_marker_server_->applyChanges();
   }
 
   // Detect when interaction stops without triggering a MOUSE_UP event by

--- a/flatland_server/src/message_server.cpp
+++ b/flatland_server/src/message_server.cpp
@@ -1,0 +1,3 @@
+#include <flatland_server/message_server.h>
+
+namespace flatland_server {}

--- a/flatland_server/src/model.cpp
+++ b/flatland_server/src/model.cpp
@@ -48,8 +48,15 @@
 #include <flatland_server/exceptions.h>
 #include <flatland_server/geometry.h>
 #include <flatland_server/model.h>
+#include <flatland_server/world.h>
 
 namespace flatland_server {
+
+Model::Model(World *world, b2World *physics_world, CollisionFilterRegistry *cfr,
+             const std::string &ns, const std::string &name)
+    : Model(physics_world, cfr, ns, name) {
+  this->world = world;
+}
 
 Model::Model(b2World *physics_world, CollisionFilterRegistry *cfr,
              const std::string &ns, const std::string &name)
@@ -74,13 +81,14 @@ Model::~Model() {
   DebugVisualization::Get().Reset(viz_name_);
 }
 
-Model *Model::MakeModel(b2World *physics_world, CollisionFilterRegistry *cfr,
+Model *Model::MakeModel(World *world, b2World *physics_world,
+                        CollisionFilterRegistry *cfr,
                         const std::string &model_yaml_path,
                         const std::string &ns, const std::string &name) {
   YamlReader reader(model_yaml_path);
   reader.SetErrorInfo("model " + Q(name));
 
-  Model *m = new Model(physics_world, cfr, ns, name);
+  Model *m = new Model(world, physics_world, cfr, ns, name);
 
   m->plugins_reader_ = reader.SubnodeOpt("plugins", YamlReader::LIST);
 
@@ -160,6 +168,21 @@ ModelBody *Model::GetBody(const std::string &name) {
     }
   }
   return nullptr;
+}
+
+ModelPlugin *Model::GetPlugin(const std::string &name) const {
+  for (const auto &plugin : GetWorld().plugin_manager_.model_plugins_) {
+    if (plugin->GetModel() == this && plugin->GetName() == name) {
+      return plugin.get();
+    }
+  }
+  return nullptr;
+}
+
+World &Model::GetWorld() const { return *world; }
+
+MessageServer &Model::GetMessageServer() const {
+  return (GetWorld().message_server);
 }
 
 Joint *Model::GetJoint(const std::string &name) {

--- a/flatland_server/src/model_plugin.cpp
+++ b/flatland_server/src/model_plugin.cpp
@@ -48,7 +48,7 @@
 
 namespace flatland_server {
 
-Model *ModelPlugin::GetModel() { return model_; }
+Model *ModelPlugin::GetModel() const { return model_; }
 
 void ModelPlugin::Initialize(const std::string &type, const std::string &name,
                              Model *model, const YAML::Node &config) {

--- a/flatland_server/src/plugin_manager.cpp
+++ b/flatland_server/src/plugin_manager.cpp
@@ -77,19 +77,39 @@ PluginManager::~PluginManager() {
 
 void PluginManager::BeforePhysicsStep(const Timekeeper &timekeeper_) {
   for (const auto &model_plugin : model_plugins_) {
+    START_PROFILE(timekeeper_, "Before Physics Step: " +
+                                   model_plugin.get()->GetModel()->name_ + " " +
+                                   model_plugin.get()->name_);
     model_plugin->BeforePhysicsStep(timekeeper_);
+    END_PROFILE(timekeeper_, "Before Physics Step: " +
+                                 model_plugin.get()->GetModel()->name_ + " " +
+                                 model_plugin.get()->name_);
   }
   for (const auto &world_plugin : world_plugins_) {
+    START_PROFILE(timekeeper_,
+                  "Before Physics Step: " + world_plugin.get()->name_);
     world_plugin->BeforePhysicsStep(timekeeper_);
+    END_PROFILE(timekeeper_,
+                "Before Physics Step: " + world_plugin.get()->name_);
   }
 }
 
 void PluginManager::AfterPhysicsStep(const Timekeeper &timekeeper_) {
   for (const auto &model_plugin : model_plugins_) {
+    START_PROFILE(timekeeper_, "After Physics Step: " +
+                                   model_plugin.get()->GetModel()->name_ + " " +
+                                   model_plugin.get()->name_);
     model_plugin->AfterPhysicsStep(timekeeper_);
+    END_PROFILE(timekeeper_, "After Physics Step: " +
+                                 model_plugin.get()->GetModel()->name_ + " " +
+                                 model_plugin.get()->name_);
   }
   for (const auto &world_plugin : world_plugins_) {
+    START_PROFILE(timekeeper_,
+                  "After Physics Step: " + world_plugin.get()->name_);
     world_plugin->AfterPhysicsStep(timekeeper_);
+    END_PROFILE(timekeeper_,
+                "After Physics Step: " + world_plugin.get()->name_);
   }
 }
 
@@ -185,7 +205,6 @@ void PluginManager::LoadWorldPlugin(World *world, YamlReader &plugin_reader,
 
   boost::shared_ptr<WorldPlugin> world_plugin;
   std::string msg = "World Plugin " + Q(name) + " type " + Q(type);
-
   YAML::Node yaml_node;
   for (const auto &k : plugin_reader.Node()) {
     if (k.first.as<std::string>() != "name" &&

--- a/flatland_server/src/service_manager.cpp
+++ b/flatland_server/src/service_manager.cpp
@@ -87,17 +87,17 @@ ServiceManager::ServiceManager(SimulationManager *sim_man, World *world)
 
 bool ServiceManager::SpawnModel(flatland_msgs::SpawnModel::Request &request,
                                 flatland_msgs::SpawnModel::Response &response) {
-  ROS_DEBUG_NAMED("ServiceManager",
-                  "Model spawn requested with path(\"%s\"), namespace(\"%s\"), "
-                  "name(\'%s\"), pose(%f,%f,%f)",
-                  request.yaml_path.c_str(), request.ns.c_str(),
-                  request.name.c_str(), request.pose.x, request.pose.y,
-                  request.pose.theta);
+  ROS_DEBUG_NAMED(
+      "ServiceManager",
+      "Model spawn requested with yaml_name(\"%s\"), namespace(\"%s\"), "
+      "name(\'%s\"), pose(%f,%f,%f)",
+      request.yaml_name.c_str(), request.ns.c_str(), request.name.c_str(),
+      request.pose.x, request.pose.y, request.pose.theta);
 
   Pose pose(request.pose.x, request.pose.y, request.pose.theta);
 
   try {
-    world_->LoadModel(request.yaml_path, request.ns, request.name, pose);
+    world_->LoadModel(request.yaml_name, request.ns, request.name, pose);
     response.success = true;
     response.message = "";
   } catch (const std::exception &e) {

--- a/flatland_server/src/simulation_manager.cpp
+++ b/flatland_server/src/simulation_manager.cpp
@@ -44,30 +44,32 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "flatland_server/simulation_manager.h"
 #include <flatland_server/debug_visualization.h>
 #include <flatland_server/layer.h>
 #include <flatland_server/model.h>
-#include <flatland_server/service_manager.h>
+#include <flatland_server/simulation_manager.h>
 #include <flatland_server/world.h>
 #include <ros/ros.h>
 #include <exception>
 #include <limits>
 #include <string>
-#include <chrono>
-#include <thread>
 
 namespace flatland_server {
 
 SimulationManager::SimulationManager(std::string world_yaml_file,
-                                     double update_rate, double step_size,
-                                     bool show_viz, double viz_pub_rate)
+                                     std::string models_path,
+                                     std::string world_plugins_path,
+                                     double update_rate,
+                                     double step_size, bool show_viz,
+                                     double viz_pub_rate)
     : world_(nullptr),
       update_rate_(update_rate),
       step_size_(step_size),
       show_viz_(show_viz),
       viz_pub_rate_(viz_pub_rate),
-      world_yaml_file_(world_yaml_file) {
+      world_yaml_file_(world_yaml_file),
+      models_path_(models_path),
+      world_plugins_path_(world_plugins_path) {
   ROS_INFO_NAMED("SimMan",
                  "Simulation params: world_yaml_file(%s) update_rate(%f), "
                  "step_size(%f) show_viz(%s), viz_pub_rate(%f)",
@@ -75,107 +77,107 @@ SimulationManager::SimulationManager(std::string world_yaml_file,
                  show_viz_ ? "true" : "false", viz_pub_rate_);
 }
 
-void SimulationManager::Main(bool benchmark) {
+void SimulationManager::Main() {
   ROS_INFO_NAMED("SimMan", "Initializing...");
   run_simulator_ = true;
 
   try {
-    world_ = World::MakeWorld(world_yaml_file_);
+    world_ =
+        World::MakeWorld(world_yaml_file_, models_path_, world_plugins_path_);
     ROS_INFO_NAMED("SimMan", "World loaded");
   } catch (const std::exception& e) {
     ROS_FATAL_NAMED("SimMan", "%s", e.what());
     return;
   }
+  service_manager_.reset(nullptr);
 
-  if (show_viz_) world_->DebugVisualize();
+  Timekeeper timekeeper;
+  ros::WallRate rate(update_rate_);
+  timekeeper.SetMaxStepSize(step_size_);
 
-  iterations_ = 0;
+  int iterations = 0;
   double filtered_cycle_util = 0;
   double min_cycle_util = std::numeric_limits<double>::infinity();
   double max_cycle_util = 0;
-  double viz_update_period = 1.0f / viz_pub_rate_;
-  ServiceManager service_manager(this, world_);
+  double viz_update_period = timekeeper.GetMaxStepSize() /
+                             rate.expectedCycleTime().toSec() / viz_pub_rate_;
 
-  // ros::WallDuration(1.0).sleep(); // sleep for one second to allow world/plugins to init
-
-  // integrated ros::WallRate logic here to expose internals for benchmarking
-  std::chrono::duration<double> start = std::chrono::steady_clock::now().time_since_epoch();
-  std::chrono::duration<double> expected_cycle_time(1.0/update_rate_);
-  std::chrono::duration<double> actual_cycle_time(0.0);
-  using seconds_d = std::chrono::duration<double, std::ratio<1, 1>>;
-  double seconds_taken = 0;
-
-  timekeeper_.SetMaxStepSize(step_size_);
-  ROS_INFO_NAMED("SimMan", "Simulation loop started");
-
+  ROS_INFO_NAMED("SimMan", "Waiting for Map");
   while (ros::ok() && run_simulator_) {
+    try {
+      world_->LoadWorldEntities();
+      if (show_viz_) {
+        world_->DebugVisualize();
+      }
+      service_manager_ =
+          std::unique_ptr<ServiceManager>(new ServiceManager(this, world_));
+      break;
+    } catch (const YAMLException& ex) {
+      std::string exception(ex.what());
+      if (exception.find("File does not exist") == std::string::npos) {
+        throw;
+      }
+      ROS_DEBUG_STREAM_THROTTLE(5, "Tried to load world yaml file "
+                                       << world_yaml_file_);
+    }
+
+    timekeeper.StepTime();
+    rate.sleep();
+  }
+
+  ROS_INFO_NAMED("SimMan", "Received Map, Simulation Loop Started");
+  while (ros::ok() && run_simulator_) {
+    START_PROFILE(timekeeper, "Total Iteration");
     // for updating visualization at a given rate
     // see flatland_plugins/update_timer.cpp for this formula
     double f = 0.0;
+    static double t_init_offset = timekeeper.GetSimTime().toSec();
     try {
-      f = fmod(ros::Time::now().toSec() +
-                   (expected_cycle_time.count() / 2.0),
+      f = fmod(timekeeper.GetSimTime().toSec() - t_init_offset +
+                   (rate.expectedCycleTime().toSec() / 2.0),
                viz_update_period);
     } catch (std::runtime_error& ex) {
       ROS_ERROR("Flatland runtime error: [%s]", ex.what());
     }
-    std::chrono::duration<double> update_start = std::chrono::steady_clock::now().time_since_epoch();
-    bool update_viz = ((f >= 0.0) && (f < expected_cycle_time.count()));
+    bool update_viz = ((f >= 0.0) && (f < rate.expectedCycleTime().toSec()));
 
-    world_->Update(timekeeper_);  // Step physics by ros cycle time
+    world_->Update(timekeeper);  // Step physics by ros cycle time
 
     if (show_viz_ && update_viz) {
       world_->DebugVisualize(false);  // no need to update layer
       DebugVisualization::Get().Publish(
-          timekeeper_);  // publish debug visualization
+          timekeeper);  // publish debug visualization
+    }
+
+    if (update_viz) {
+      START_PROFILE(timekeeper, "Update Interactive Marker");
+      world_->int_marker_manager_.update();
+      END_PROFILE(timekeeper, "Update Interactive Marker");
     }
 
     ros::spinOnce();
 
-    seconds_taken += (seconds_d(std::chrono::steady_clock::now().time_since_epoch()) - update_start).count();
+    END_PROFILE(timekeeper, "Total Iteration");
+    rate.sleep();
 
-    // ros::WallRate::sleep() logic, but using std::chrono time
-    {
-      std::chrono::duration<double> expected_end = start + expected_cycle_time;
-      std::chrono::duration<double> actual_end = std::chrono::steady_clock::now().time_since_epoch();
-      std::chrono::duration<double> sleep_time = expected_end - actual_end;  //calculate the time we'll sleep for
-      actual_cycle_time = actual_end - start;
-      start = expected_end;  //make sure to reset our start time
-      // ROS_INFO_NAMED(
-      //   "SimMan", "actual_end: %f, start: %f, actual: %f", 
-      //   seconds_d(actual_end).count(), 
-      //   seconds_d(start).count(), 
-      //   seconds_d(actual_cycle_time).count());
-      if(sleep_time.count() <= 0.0) { //if we've taken too much time we won't sleep
-        if (actual_end > expected_end + expected_cycle_time) {
-          start = actual_end;
-        }
-      } else {  // sleep, unless we're in a benchmark
-        if (benchmark == false) {   // if benchmark==true, skip sleeping to run as fast as possible
-          std::this_thread::sleep_for(sleep_time);
-        } else {
-          start = actual_end;
-        }
-      }
-    }
+    iterations++;
 
-    iterations_++;
-
-    double cycle_time = actual_cycle_time.count() * 1000;
-    double expected_cycle_time_ms = expected_cycle_time.count() * 1000;
-    double cycle_util = cycle_time / expected_cycle_time_ms * 100;  // in percent
-    double factor = timekeeper_.GetStepSize() * 1000 / expected_cycle_time_ms;
+    double cycle_time = rate.cycleTime().toSec() * 1000;
+    double expected_cycle_time = rate.expectedCycleTime().toSec() * 1000;
+    double cycle_util = cycle_time / expected_cycle_time * 100;  // in percent
+    double factor = timekeeper.GetStepSize() * 1000 / expected_cycle_time;
     min_cycle_util = std::min(cycle_util, min_cycle_util);
-    if (iterations_ > 10) max_cycle_util = std::max(cycle_util, max_cycle_util);
+    if (iterations > 10) max_cycle_util = std::max(cycle_util, max_cycle_util);
     filtered_cycle_util = 0.99 * filtered_cycle_util + 0.01 * cycle_util;
 
-    ROS_INFO_THROTTLE_NAMED(
-        1, "SimMan",
-        "utilization: min %.1f%% max %.1f%% ave %.1f%%  factor: %.1f",
-        min_cycle_util, max_cycle_util, filtered_cycle_util, factor);
+    ROS_DEBUG_THROTTLE_NAMED(
+       1, "SimMan",
+       "utilization: min %.1f%% max %.1f%% ave %.1f%%  factor: %.1f",
+       min_cycle_util, max_cycle_util, filtered_cycle_util, factor);
   }
-  // std::cout << "Simulation loop ended. " << iterations_ << " iterations in " << seconds_taken << " seconds, " <<  (double)iterations_/seconds_taken << " iterations/sec" << std::endl;
+  ROS_INFO_NAMED("SimMan", "Simulation loop ended");
 
+  PRINT_ALL_PROFILES(timekeeper);
   delete world_;
 }
 

--- a/flatland_server/src/timekeeper.cpp
+++ b/flatland_server/src/timekeeper.cpp
@@ -50,7 +50,10 @@
 namespace flatland_server {
 
 Timekeeper::Timekeeper()
-    : time_(ros::Time(0, 0)), max_step_size_(0), clock_topic_("/clock") {
+    : time_(ros::Time(ros::WallTime::now().toSec(),
+                      ros::WallTime::now().toNSec())),
+      max_step_size_(0),
+      clock_topic_("/clock") {
   clock_pub_ = nh_.advertise<rosgraph_msgs::Clock>(clock_topic_, 1);
 }
 

--- a/flatland_server/src/world.cpp
+++ b/flatland_server/src/world.cpp
@@ -100,13 +100,21 @@ World::~World() {
 
 void World::Update(Timekeeper &timekeeper) {
   if (!IsPaused()) {
+    START_PROFILE(timekeeper, "Before Physics Step");
     plugin_manager_.BeforePhysicsStep(timekeeper);
+    END_PROFILE(timekeeper, "Before Physics Step");
+
+    START_PROFILE(timekeeper, "Physics Step");
     physics_world_->Step(timekeeper.GetStepSize(), physics_velocity_iterations_,
                          physics_position_iterations_);
+    END_PROFILE(timekeeper, "Physics Step");
+
     timekeeper.StepTime();
+
+    START_PROFILE(timekeeper, "After Physics Step");
     plugin_manager_.AfterPhysicsStep(timekeeper);
+    END_PROFILE(timekeeper, "After Physics Step");
   }
-  int_marker_manager_.update();
 }
 
 void World::BeginContact(b2Contact *contact) {
@@ -125,9 +133,15 @@ void World::PostSolve(b2Contact *contact, const b2ContactImpulse *impulse) {
   plugin_manager_.PostSolve(contact, impulse);
 }
 
-World *World::MakeWorld(const std::string &yaml_path) {
-  YamlReader world_reader = YamlReader(yaml_path);
-  YamlReader prop_reader = world_reader.Subnode("properties", YamlReader::MAP);
+World *World::MakeWorld(const std::string &yaml_path,
+                        const std::string &models_path,
+                        const std::string &world_plugins_path) {
+  YamlReader world_settings_reader = YamlReader(world_plugins_path);
+  YamlReader prop_reader =
+      world_settings_reader.Subnode("properties", YamlReader::MAP);
+  YamlReader world_plugin_reader =
+      world_settings_reader.SubnodeOpt("plugins", YamlReader::LIST);
+
   int v = prop_reader.Get<int>("velocity_iterations", 10);
   int p = prop_reader.Get<int>("position_iterations", 10);
   prop_reader.EnsureAccessedAllKeys();
@@ -137,17 +151,14 @@ World *World::MakeWorld(const std::string &yaml_path) {
   w->world_yaml_dir_ = boost::filesystem::path(yaml_path).parent_path();
   w->physics_velocity_iterations_ = v;
   w->physics_position_iterations_ = p;
+  w->models_path_ = models_path;
+  w->yaml_path_ = yaml_path;
 
   try {
-    YamlReader layers_reader = world_reader.Subnode("layers", YamlReader::LIST);
-    YamlReader models_reader =
-        world_reader.SubnodeOpt("models", YamlReader::LIST);
-    YamlReader world_plugin_reader =
-        world_reader.SubnodeOpt("plugins", YamlReader::LIST);
-    world_reader.EnsureAccessedAllKeys();
-    w->LoadLayers(layers_reader);
-    w->LoadModels(models_reader);
-    w->LoadWorldPlugins(world_plugin_reader, w, world_reader);
+    w->LoadWorldPlugins(world_plugin_reader, w, world_settings_reader);
+
+    world_settings_reader.EnsureAccessedAllKeys();
+
   } catch (const YAMLException &e) {
     ROS_FATAL_NAMED("World", "Error loading from YAML");
     delete w;
@@ -164,7 +175,35 @@ World *World::MakeWorld(const std::string &yaml_path) {
   return w;
 }
 
+void World::LoadWorldEntities() {
+  try {
+    YamlReader map_info_reader = YamlReader(yaml_path_);
+    YamlReader layers_reader =
+        map_info_reader.Subnode("layers", YamlReader::LIST);
+    YamlReader models_reader =
+        map_info_reader.SubnodeOpt("models", YamlReader::LIST);
+
+    this->LoadLayers(layers_reader);
+    this->LoadModels(models_reader);
+
+  } catch (const YAMLException &e) {
+    ROS_WARN_STREAM_DELAYED_THROTTLE_NAMED(1, "World", yaml_path_
+                                                           << "not loaded yet");
+    throw e;
+  } catch (const PluginException &e) {
+    ROS_FATAL_NAMED("World", "Error loading plugins");
+    throw e;
+  } catch (const Exception &e) {
+    ROS_FATAL_NAMED("World", "Error loading world");
+    throw e;
+  }
+}
+
 void World::LoadLayers(YamlReader &layers_reader) {
+  layers_name_map_.clear();
+  layers_.clear();
+  cfr_.ClearAllLayers();
+
   // loop through each layer and parse the data
   for (int i = 0; i < layers_reader.NodeSize(); i++) {
     YamlReader reader = layers_reader.Subnode(i, YamlReader::MAP);
@@ -220,13 +259,29 @@ void World::LoadModels(YamlReader &models_reader) {
   if (!models_reader.IsNodeNull()) {
     for (int i = 0; i < models_reader.NodeSize(); i++) {
       YamlReader reader = models_reader.Subnode(i, YamlReader::MAP);
+      std::string name = reader.Get<std::string>("name");
+      models_.erase(
+          std::remove_if(models_.begin(), models_.end(),
+                         [&name](const Model *m) { return m->name_ == name; }),
+          models_.end());
+    }
+
+    for (int i = 0; i < models_reader.NodeSize(); i++) {
+      YamlReader reader = models_reader.Subnode(i, YamlReader::MAP);
 
       std::string name = reader.Get<std::string>("name");
       std::string ns = reader.Get<std::string>("namespace", "");
       Pose pose = reader.GetPose("pose", Pose(0, 0, 0));
       std::string path = reader.Get<std::string>("model");
       reader.EnsureAccessedAllKeys();
-      LoadModel(path, ns, name, pose);
+
+      if (std::find_if(models_.begin(), models_.end(), [&name](const Model *m) {
+            return m->name_ == name;
+          }) != models_.end()) {
+        throw YAMLException("Model with name " + Q(name) + " already exists");
+      }
+
+      LoadModel(models_path_ + "/" + path, ns, name, pose);
     }
   }
 }
@@ -243,22 +298,24 @@ void World::LoadWorldPlugins(YamlReader &world_plugin_reader, World *world,
 }
 void World::LoadModel(const std::string &model_yaml_path, const std::string &ns,
                       const std::string &name, const Pose &pose) {
-  // ensure no duplicate model names
-  if (std::count_if(models_.begin(), models_.end(),
-                    [&](Model *m) { return m->name_ == name; }) >= 1) {
-    throw YAMLException("Model with name " + Q(name) + " already exists");
+  // If the model is already loaded, move the model instead
+  if (std::find_if(models_.begin(), models_.end(), [&name](const Model *m) {
+        return m->name_ == name;
+      }) != models_.end()) {
+    MoveModel(name, pose);
+    return;
   }
 
   boost::filesystem::path abs_path(model_yaml_path);
   if (model_yaml_path.front() != '/') {
-    abs_path = world_yaml_dir_ / abs_path;
+    abs_path = models_path_ / abs_path;
   }
 
   ROS_INFO_NAMED("World", "Loading model from path=\"%s\"",
                  abs_path.string().c_str());
 
-  Model *m =
-      Model::MakeModel(physics_world_, &cfr_, abs_path.string(), ns, name);
+  Model *m = Model::MakeModel(this, physics_world_, &cfr_, abs_path.string(),
+                              ns, name);
   m->TransformAll(pose);
 
   try {
@@ -281,7 +338,9 @@ void World::LoadModel(const std::string &model_yaml_path, const std::string &ns,
   visualization_msgs::MarkerArray body_markers;
   for (size_t i = 0; i < m->bodies_.size(); i++) {
     DebugVisualization::Get().BodyToMarkers(
-        body_markers, m->bodies_[i]->physics_body_, 1.0, 0.0, 0.0, 1.0);
+        body_markers, m->bodies_[i]->physics_body_, m->bodies_[i]->color_.r,
+        m->bodies_[i]->color_.g, m->bodies_[i]->color_.b,
+        m->bodies_[i]->color_.a);
   }
   int_marker_manager_.createInteractiveMarker(name, pose, body_markers);
 
@@ -309,6 +368,17 @@ void World::DeleteModel(const std::string &name) {
     throw Exception("Flatland World: failed to delete model, model with name " +
                     Q(name) + " does not exist");
   }
+}
+
+const Model *World::GetModel(const std::string &name) {
+  for (const auto &model : models_) {
+    if (model->GetName() == name) {
+      return model;
+    }
+  }
+
+  throw Exception("Flatland World: failed to find model, model with name " +
+                  Q(name) + " does not exist");
 }
 
 void World::MoveModel(const std::string &name, const Pose &pose) {

--- a/flatland_server/test/conestogo_office_test/world_plugins.yaml
+++ b/flatland_server/test/conestogo_office_test/world_plugins.yaml
@@ -1,0 +1,9 @@
+properties: {}
+plugins:
+  - name: test1
+    type: RandomWall
+    layer: "2d"
+    num_of_walls: 10
+    wall_wall_dist: 1
+    double_wall: true
+    robot_name: cleaner1

--- a/flatland_server/test/debug_visualization_test.cpp
+++ b/flatland_server/test/debug_visualization_test.cpp
@@ -100,9 +100,10 @@ TEST(DebugVizTest, testBodyToMarkersPolygon) {
   ASSERT_NEAR(markers.markers[0].pose.orientation.w, 0.70710678118, 1e-5);
 
   // Check the marker shape
-  ASSERT_EQ(markers.markers[0].type, markers.markers[0].LINE_STRIP);
-  ASSERT_EQ(markers.markers[0].points.size(),
-            5);  // box as line strip: 0, 1, 2, 3, 0
+  ASSERT_EQ(markers.markers[0].type, markers.markers[0].TRIANGLE_LIST);
+  ASSERT_EQ(markers.markers[0].points.size(), 6);
+
+  // Assert locations
   ASSERT_NEAR(markers.markers[0].points[0].x, -1.0, 1e-5);
   ASSERT_NEAR(markers.markers[0].points[0].y, -2.0, 1e-5);
   ASSERT_NEAR(markers.markers[0].points[1].x, 1.0, 1e-5);
@@ -110,9 +111,11 @@ TEST(DebugVizTest, testBodyToMarkersPolygon) {
   ASSERT_NEAR(markers.markers[0].points[2].x, 1.0, 1e-5);
   ASSERT_NEAR(markers.markers[0].points[2].y, 2.0, 1e-5);
   ASSERT_NEAR(markers.markers[0].points[3].x, -1.0, 1e-5);
-  ASSERT_NEAR(markers.markers[0].points[3].y, 2.0, 1e-5);
-  ASSERT_NEAR(markers.markers[0].points[4].x, -1.0, 1e-5);
-  ASSERT_NEAR(markers.markers[0].points[4].y, -2.0, 1e-5);
+  ASSERT_NEAR(markers.markers[0].points[3].y, -2.0, 1e-5);
+  ASSERT_NEAR(markers.markers[0].points[4].x, 1.0, 1e-5);
+  ASSERT_NEAR(markers.markers[0].points[4].y, 2.0, 1e-5);
+  ASSERT_NEAR(markers.markers[0].points[5].x, -1.0, 1e-5);
+  ASSERT_NEAR(markers.markers[0].points[5].y, 2.0, 1e-5);
 }
 
 // Test the bodyToMarkers method on a circle shape

--- a/flatland_server/test/load_world_test.cpp
+++ b/flatland_server/test/load_world_test.cpp
@@ -62,7 +62,7 @@ using namespace flatland_server;
 class LoadWorldTest : public ::testing::Test {
  protected:
   boost::filesystem::path this_file_dir;
-  boost::filesystem::path world_yaml;
+  boost::filesystem::path world_yaml_path;
   World *w;
 
   void SetUp() override {
@@ -78,13 +78,16 @@ class LoadWorldTest : public ::testing::Test {
 
   // to test that the world instantiation will fail, and the exception
   // message matches the given regex string
-  void test_yaml_fail(std::string regex_str) {
+  void test_yaml_fail(const std::string &regex_str) {
     // do a regex match against error messages
     std::cmatch match;
     std::regex regex(regex_str);
 
     try {
-      w = World::MakeWorld(world_yaml.string());
+      w = World::MakeWorld(world_yaml_path.string() + "world.yaml",
+                           world_yaml_path.string(),
+                           world_yaml_path.string() + "world_plugins.yaml");
+      w->LoadWorldEntities();
       ADD_FAILURE() << "Expected an exception, but none were raised";
     } catch (const Exception &e) {
       EXPECT_TRUE(std::regex_match(e.what(), match, regex))
@@ -514,9 +517,11 @@ class LoadWorldTest : public ::testing::Test {
  * correct after instantiation
  */
 TEST_F(LoadWorldTest, simple_test_A) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/simple_test_A/world.yaml");
-  w = World::MakeWorld(world_yaml.string());
+  world_yaml_path = this_file_dir / fs::path("load_world_tests/simple_test_A/");
+  w = World::MakeWorld(world_yaml_path.string() + "world.yaml",
+                       world_yaml_path.string(),
+                       world_yaml_path.string() + "world_plugins.yaml");
+  w->LoadWorldEntities();
 
   EXPECT_EQ(w->physics_velocity_iterations_, 11);
   EXPECT_EQ(w->physics_position_iterations_, 12);
@@ -753,11 +758,11 @@ TEST_F(LoadWorldTest, simple_test_A) {
  * an exception
  */
 TEST_F(LoadWorldTest, wrong_world_path) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/random_path/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("load_world_tests/random_path/");
+
   test_yaml_fail(
       "Flatland YAML: File does not exist, "
-      "path=\".*/load_world_tests/random_path/world.yaml\".*");
+      "path=\".*/load_world_tests/random_path/world_plugins.yaml\".*");
 }
 
 /**
@@ -765,8 +770,8 @@ TEST_F(LoadWorldTest, wrong_world_path) {
  * an exception.
  */
 TEST_F(LoadWorldTest, world_invalid_A) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/world_invalid_A/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/world_invalid_A/");
   test_yaml_fail("Flatland YAML: Entry \"properties\" does not exist");
 }
 
@@ -775,8 +780,8 @@ TEST_F(LoadWorldTest, world_invalid_A) {
  * an exception.
  */
 TEST_F(LoadWorldTest, world_invalid_B) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/world_invalid_B/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/world_invalid_B/");
   test_yaml_fail(
       "Flatland YAML: Entry \"color\" must have size of exactly 4 \\(in "
       "\"layers\" index=0\\)");
@@ -787,8 +792,8 @@ TEST_F(LoadWorldTest, world_invalid_B) {
  * an exception.
  */
 TEST_F(LoadWorldTest, world_invalid_C) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/world_invalid_C/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/world_invalid_C/");
   test_yaml_fail(
       "Flatland YAML: Entry index=0 contains unrecognized entry\\(s\\) "
       "\\{\"random_param_1\", \"random_param_2\", \"random_param_3\"\\} \\(in "
@@ -800,8 +805,8 @@ TEST_F(LoadWorldTest, world_invalid_C) {
  * an exception.
  */
 TEST_F(LoadWorldTest, world_invalid_D) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/world_invalid_D/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/world_invalid_D/");
   test_yaml_fail("Flatland YAML: Layer with name \"layer\" already exists");
 }
 
@@ -810,8 +815,8 @@ TEST_F(LoadWorldTest, world_invalid_D) {
  * an exception.
  */
 TEST_F(LoadWorldTest, world_invalid_E) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/world_invalid_E/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/world_invalid_E/");
   test_yaml_fail("Flatland YAML: Model with name \"turtlebot\" already exists");
 }
 
@@ -820,8 +825,8 @@ TEST_F(LoadWorldTest, world_invalid_E) {
  * an exception.
  */
 TEST_F(LoadWorldTest, world_invalid_F) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/world_invalid_F/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/world_invalid_F/");
   test_yaml_fail(
       "Flatland YAML: Unable to add 3 additional layer\\(s\\) \\{layer_15, "
       "layer_16, layer_17\\}, current layers count is 14, max allowed is 16");
@@ -832,8 +837,7 @@ TEST_F(LoadWorldTest, world_invalid_F) {
  * load a invalid map yaml file. It should throw an exception.
  */
 TEST_F(LoadWorldTest, map_invalid_A) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/map_invalid_A/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("load_world_tests/map_invalid_A/");
   test_yaml_fail(
       "Flatland YAML: Entry \"origin\" does not exist \\(in layer "
       "\"2d\"\\)");
@@ -845,8 +849,7 @@ TEST_F(LoadWorldTest, map_invalid_A) {
  * throw an exception
  */
 TEST_F(LoadWorldTest, map_invalid_B) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/map_invalid_B/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("load_world_tests/map_invalid_B/");
   test_yaml_fail("Flatland YAML: Failed to load \".*\\.png\" in layer \"2d\"");
 }
 
@@ -855,8 +858,7 @@ TEST_F(LoadWorldTest, map_invalid_B) {
  * thrown
  */
 TEST_F(LoadWorldTest, map_invalid_C) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/map_invalid_C/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("load_world_tests/map_invalid_C/");
   test_yaml_fail(
       "Flatland File: Failed to load \".*/map_invalid_C/random_file.dat\"");
 }
@@ -866,8 +868,7 @@ TEST_F(LoadWorldTest, map_invalid_C) {
  * thrown
  */
 TEST_F(LoadWorldTest, map_invalid_D) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/map_invalid_D/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("load_world_tests/map_invalid_D/");
   test_yaml_fail(
       "Flatland File: Failed to read line segment from line 6, in file "
       "\"map_lines.dat\"");
@@ -878,8 +879,7 @@ TEST_F(LoadWorldTest, map_invalid_D) {
  * thrown
  */
 TEST_F(LoadWorldTest, map_invalid_E) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/map_invalid_E/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("load_world_tests/map_invalid_E/");
   test_yaml_fail(
       "Flatland YAML: Entry \"scale\" does not exist \\(in layer \"lines\"\\)");
 }
@@ -888,8 +888,8 @@ TEST_F(LoadWorldTest, map_invalid_E) {
  * This test tries to load a invalid model yaml file, it should fail
  */
 TEST_F(LoadWorldTest, model_invalid_A) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/model_invalid_A/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/model_invalid_A/");
   test_yaml_fail(
       "Flatland YAML: Entry \"bodies\" must be a list \\(in model "
       "\"turtlebot\"\\)");
@@ -899,8 +899,8 @@ TEST_F(LoadWorldTest, model_invalid_A) {
  * This test tries to load a invalid model yaml file, it should fail
  */
 TEST_F(LoadWorldTest, model_invalid_B) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/model_invalid_B/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/model_invalid_B/");
   test_yaml_fail(
       "Flatland YAML: Entry \"points\" must have size >= 3 \\(in model "
       "\"turtlebot\" body \"base\" \"footprints\" index=1\\)");
@@ -910,8 +910,8 @@ TEST_F(LoadWorldTest, model_invalid_B) {
  * This test tries to load a invalid model yaml file, it should fail
  */
 TEST_F(LoadWorldTest, model_invalid_C) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/model_invalid_C/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/model_invalid_C/");
   test_yaml_fail(
       "Flatland YAML: Entry \"anchor\" must have size of exactly 2 \\(in model "
       "\"turtlebot\" joint \"right_wheel_weld\" \"bodies\" index=1\\)");
@@ -921,8 +921,8 @@ TEST_F(LoadWorldTest, model_invalid_C) {
  * This test tries to load a invalid model yaml file, it should fail
  */
 TEST_F(LoadWorldTest, model_invalid_D) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/model_invalid_D/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/model_invalid_D/");
   test_yaml_fail(
       "Flatland YAML: Cannot find body with name \"left_wheel_123\" in model "
       "\"turtlebot\" joint \"left_wheel_weld\" \"bodies\" index=1");
@@ -932,8 +932,8 @@ TEST_F(LoadWorldTest, model_invalid_D) {
  * This test tries to load a invalid model yaml file, it should fail
  */
 TEST_F(LoadWorldTest, model_invalid_E) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/model_invalid_E/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/model_invalid_E/");
   test_yaml_fail(
       "Flatland YAML: Invalid footprint \"layers\" in model \"turtlebot\" body "
       "\"left_wheel\" \"footprints\" index=0, \\{random_layer\\} layer\\(s\\) "
@@ -944,8 +944,8 @@ TEST_F(LoadWorldTest, model_invalid_E) {
  * This test tries to load a invalid model yaml file, it should fail
  */
 TEST_F(LoadWorldTest, model_invalid_F) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/model_invalid_F/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/model_invalid_F/");
   test_yaml_fail(
       "Flatland YAML: Entry index=0 contains unrecognized entry\\(s\\) "
       "\\{\"random_paramter\"\\} \\(in model \"turtlebot\" body \"base\" "
@@ -956,8 +956,8 @@ TEST_F(LoadWorldTest, model_invalid_F) {
  * This test tries to load a invalid model yaml file, it should fail
  */
 TEST_F(LoadWorldTest, model_invalid_G) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/model_invalid_G/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/model_invalid_G/");
   test_yaml_fail(
       "Flatland YAML: Entry body \"base\" contains unrecognized entry\\(s\\) "
       "\\{\"random_paramter\"\\} \\(in model \"turtlebot\"\\)");
@@ -967,8 +967,8 @@ TEST_F(LoadWorldTest, model_invalid_G) {
  * This test tries to load a invalid model yaml file, it should fail
  */
 TEST_F(LoadWorldTest, model_invalid_H) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/model_invalid_H/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/model_invalid_H/");
   test_yaml_fail(
       "Flatland YAML: Invalid \"bodies\" in \"turtlebot\" model, body with "
       "name \"base\" already exists");
@@ -978,8 +978,8 @@ TEST_F(LoadWorldTest, model_invalid_H) {
  * This test tries to load a invalid model yaml file, it should fail
  */
 TEST_F(LoadWorldTest, model_invalid_I) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/model_invalid_I/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/model_invalid_I/");
   test_yaml_fail(
       "Flatland YAML: Invalid \"joints\" in \"turtlebot\" model, joint with "
       "name \"wheel_weld\" already exists");
@@ -989,8 +989,8 @@ TEST_F(LoadWorldTest, model_invalid_I) {
  * This test tries to load a invalid model yaml file, it should fail
  */
 TEST_F(LoadWorldTest, model_invalid_J) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/model_invalid_J/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/model_invalid_J/");
   test_yaml_fail(
       "Flatland YAML: Entry \"points\" must have size <= 8 \\(in model "
       "\"turtlebot\" body \"base\" \"footprints\" index=1\\)");

--- a/flatland_server/test/load_world_tests/map_invalid_A/world.yaml
+++ b/flatland_server/test/load_world_tests/map_invalid_A/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "2d"
     map: "map.yaml"

--- a/flatland_server/test/load_world_tests/map_invalid_A/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/map_invalid_A/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/map_invalid_B/world.yaml
+++ b/flatland_server/test/load_world_tests/map_invalid_B/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "2d"
     map: "map.yaml"

--- a/flatland_server/test/load_world_tests/map_invalid_B/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/map_invalid_B/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/map_invalid_C/world.yaml
+++ b/flatland_server/test/load_world_tests/map_invalid_C/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "2d"
     map: "../simple_test_A/map.yaml"

--- a/flatland_server/test/load_world_tests/map_invalid_C/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/map_invalid_C/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/map_invalid_D/world.yaml
+++ b/flatland_server/test/load_world_tests/map_invalid_D/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "2d"
     map: "../simple_test_A/map.yaml"

--- a/flatland_server/test/load_world_tests/map_invalid_D/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/map_invalid_D/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/map_invalid_E/world.yaml
+++ b/flatland_server/test/load_world_tests/map_invalid_E/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "2d"
     map: "../simple_test_A/map.yaml"

--- a/flatland_server/test/load_world_tests/map_invalid_E/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/map_invalid_E/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/model_invalid_A/world.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_A/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers: []
 models: 
   - name: turtlebot

--- a/flatland_server/test/load_world_tests/model_invalid_A/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_A/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/model_invalid_B/world.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_B/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers: []
 models: 
   - name: turtlebot

--- a/flatland_server/test/load_world_tests/model_invalid_B/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_B/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/model_invalid_C/world.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_C/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers: []
 models: 
   - name: turtlebot

--- a/flatland_server/test/load_world_tests/model_invalid_C/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_C/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/model_invalid_D/world.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_D/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers: []
 models: 
   - name: turtlebot

--- a/flatland_server/test/load_world_tests/model_invalid_D/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_D/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/model_invalid_E/world.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_E/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "2d"
     map: "../simple_test_A/map.yaml"

--- a/flatland_server/test/load_world_tests/model_invalid_E/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_E/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/model_invalid_F/world.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_F/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers: []
 models: 
   - name: turtlebot

--- a/flatland_server/test/load_world_tests/model_invalid_F/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_F/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/model_invalid_G/world.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_G/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers: []
 models: 
   - name: turtlebot

--- a/flatland_server/test/load_world_tests/model_invalid_G/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_G/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/model_invalid_H/world.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_H/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers: []
 models: 
   - name: turtlebot

--- a/flatland_server/test/load_world_tests/model_invalid_H/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_H/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/model_invalid_I/world.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_I/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers: []
 models: 
   - name: turtlebot

--- a/flatland_server/test/load_world_tests/model_invalid_I/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_I/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/model_invalid_J/world.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_J/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers: []
 models: 
   - name: turtlebot

--- a/flatland_server/test/load_world_tests/model_invalid_J/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_J/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/simple_test_A/world.yaml
+++ b/flatland_server/test/load_world_tests/simple_test_A/world.yaml
@@ -1,6 +1,3 @@
-properties: 
-  velocity_iterations: 11
-  position_iterations: 12
 layers:
   - name: "2d"
     map: "map.yaml"

--- a/flatland_server/test/load_world_tests/simple_test_A/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/simple_test_A/world_plugins.yaml
@@ -1,0 +1,3 @@
+properties:
+  velocity_iterations: 11
+  position_iterations: 12

--- a/flatland_server/test/load_world_tests/world_invalid_A/world.yaml
+++ b/flatland_server/test/load_world_tests/world_invalid_A/world.yaml
@@ -1,4 +1,3 @@
-properties_____: {} # invalid
 layers:
   - name: "2d"
     map: "map.yaml"

--- a/flatland_server/test/load_world_tests/world_invalid_A/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/world_invalid_A/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties_____: {} # invalid

--- a/flatland_server/test/load_world_tests/world_invalid_B/world.yaml
+++ b/flatland_server/test/load_world_tests/world_invalid_B/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "2d"
     map: "map.yaml"

--- a/flatland_server/test/load_world_tests/world_invalid_B/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/world_invalid_B/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/world_invalid_C/world.yaml
+++ b/flatland_server/test/load_world_tests/world_invalid_C/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "2d"
     map: "map.yaml"

--- a/flatland_server/test/load_world_tests/world_invalid_C/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/world_invalid_C/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/world_invalid_D/world.yaml
+++ b/flatland_server/test/load_world_tests/world_invalid_D/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "layer"
     map: "../simple_test_A/map.yaml"

--- a/flatland_server/test/load_world_tests/world_invalid_D/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/world_invalid_D/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/world_invalid_E/world.yaml
+++ b/flatland_server/test/load_world_tests/world_invalid_E/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "2d"
     map: "../simple_test_A/map.yaml"

--- a/flatland_server/test/load_world_tests/world_invalid_E/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/world_invalid_E/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/world_invalid_F/world.yaml
+++ b/flatland_server/test/load_world_tests/world_invalid_F/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - {name: "layer_1", map: "../simple_test_A/map.yaml"}
   - {name: ["layer_2", "layer_3", "layer_4"], map: "../simple_test_A/map.yaml"}

--- a/flatland_server/test/load_world_tests/world_invalid_F/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/world_invalid_F/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/plugin_manager_test.cpp
+++ b/flatland_server/test/plugin_manager_test.cpp
@@ -118,7 +118,8 @@ class TestModelPlugin : public ModelPlugin {
 class PluginManagerTest : public ::testing::Test {
  protected:
   boost::filesystem::path this_file_dir;
-  boost::filesystem::path world_yaml;
+  boost::filesystem::path world_yaml_dir;
+
   Timekeeper timekeeper;
   World *w;
 
@@ -178,10 +179,14 @@ class PluginManagerTest : public ::testing::Test {
  * called with the expected inputs
  */
 TEST_F(PluginManagerTest, collision_test) {
-  world_yaml = this_file_dir /
-               fs::path("plugin_manager_tests/collision_test/world.yaml");
+  world_yaml_dir =
+      this_file_dir / fs::path("plugin_manager_tests/collision_test/");
+
   timekeeper.SetMaxStepSize(1.0);
-  w = World::MakeWorld(world_yaml.string());
+  w = World::MakeWorld(world_yaml_dir.string() + "world.yaml",
+                       world_yaml_dir.string(),
+                       world_yaml_dir.string() + "world_plugins.yaml");
+  w->LoadWorldEntities();
   Layer *l = w->layers_[0];
   Model *m0 = w->models_[0];
   Model *m1 = w->models_[1];
@@ -236,7 +241,7 @@ TEST_F(PluginManagerTest, collision_test) {
   // move the body 1m down over 2 timesteps, this should place model 0 in
   // contact with model 1
   b0->physics_body_->SetLinearVelocity(b2Vec2(0, 0));
-  b1->physics_body_->SetLinearVelocity(b2Vec2(0, -0.5));
+  b1->physics_body_->SetLinearVelocity(b2Vec2(0, -0.5f));
   w->Update(timekeeper);
   w->Update(timekeeper);
   EXPECT_TRUE(FunctionCallEq(p, {{"OnInitialize", false},
@@ -299,11 +304,13 @@ TEST_F(PluginManagerTest, collision_test) {
 }
 
 TEST_F(PluginManagerTest, load_dummy_test) {
-  world_yaml = this_file_dir /
-               fs::path("plugin_manager_tests/load_dummy_test/world.yaml");
+  world_yaml_dir =
+      this_file_dir / fs::path("plugin_manager_tests/load_dummy_test/");
 
-  w = World::MakeWorld(world_yaml.string());
-
+  w = World::MakeWorld(world_yaml_dir.string() + "world.yaml",
+                       world_yaml_dir.string(),
+                       world_yaml_dir.string() + "world_plugins.yaml");
+  w->LoadWorldEntities();
   ModelPlugin *p = w->plugin_manager_.model_plugins_[0].get();
 
   EXPECT_STREQ(p->GetType().c_str(), "DummyModelPlugin");
@@ -311,12 +318,13 @@ TEST_F(PluginManagerTest, load_dummy_test) {
 }
 
 TEST_F(PluginManagerTest, plugin_throws_exception) {
-  world_yaml =
-      this_file_dir /
-      fs::path("plugin_manager_tests/plugin_throws_exception/world.yaml");
-
+  world_yaml_dir =
+      this_file_dir / fs::path("plugin_manager_tests/plugin_throws_exception/");
   try {
-    w = World::MakeWorld(world_yaml.string());
+    w = World::MakeWorld(world_yaml_dir.string() + "world.yaml",
+                         world_yaml_dir.string(),
+                         world_yaml_dir.string() + "world_plugins.yaml");
+    w->LoadWorldEntities();
     FAIL() << "Expected an exception, but none were raised";
   } catch (const PluginException &e) {
     // do a regex match against error message
@@ -336,11 +344,14 @@ TEST_F(PluginManagerTest, plugin_throws_exception) {
 }
 
 TEST_F(PluginManagerTest, nonexistent_plugin) {
-  world_yaml = this_file_dir /
-               fs::path("plugin_manager_tests/nonexistent_plugin/world.yaml");
+  world_yaml_dir =
+      this_file_dir / fs::path("plugin_manager_tests/nonexistent_plugin/");
 
   try {
-    w = World::MakeWorld(world_yaml.string());
+    w = World::MakeWorld(world_yaml_dir.string() + "world.yaml",
+                         world_yaml_dir.string(),
+                         world_yaml_dir.string() + "world_plugins.yaml");
+    w->LoadWorldEntities();
     FAIL() << "Expected an exception, but none were raised";
   } catch (const PluginException &e) {
     std::cmatch match;
@@ -359,11 +370,14 @@ TEST_F(PluginManagerTest, nonexistent_plugin) {
 }
 
 TEST_F(PluginManagerTest, invalid_plugin_yaml) {
-  world_yaml = this_file_dir /
-               fs::path("plugin_manager_tests/invalid_plugin_yaml/world.yaml");
+  world_yaml_dir =
+      this_file_dir / fs::path("plugin_manager_tests/invalid_plugin_yaml/");
 
   try {
-    w = World::MakeWorld(world_yaml.string());
+    w = World::MakeWorld(world_yaml_dir.string() + "world.yaml",
+                         world_yaml_dir.string(),
+                         world_yaml_dir.string() + "world_plugins.yaml");
+    w->LoadWorldEntities();
     FAIL() << "Expected an exception, but none were raised";
   } catch (const YAMLException &e) {
     EXPECT_STREQ(
@@ -378,11 +392,14 @@ TEST_F(PluginManagerTest, invalid_plugin_yaml) {
 }
 
 TEST_F(PluginManagerTest, duplicate_plugin) {
-  world_yaml = this_file_dir /
-               fs::path("plugin_manager_tests/duplicate_plugin/world.yaml");
+  world_yaml_dir =
+      this_file_dir / fs::path("plugin_manager_tests/duplicate_plugin/");
 
   try {
-    w = World::MakeWorld(world_yaml.string());
+    w = World::MakeWorld(world_yaml_dir.string() + "world.yaml",
+                         world_yaml_dir.string(),
+                         world_yaml_dir.string() + "world_plugins.yaml");
+    w->LoadWorldEntities();
     FAIL() << "Expected an exception, but none were raised";
   } catch (const YAMLException &e) {
     EXPECT_STREQ(

--- a/flatland_server/test/plugin_manager_tests/collision_test/world.yaml
+++ b/flatland_server/test/plugin_manager_tests/collision_test/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "2d"
     map: "../load_dummy_test/map.yaml"

--- a/flatland_server/test/plugin_manager_tests/collision_test/world_plugins.yaml
+++ b/flatland_server/test/plugin_manager_tests/collision_test/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/plugin_manager_tests/duplicate_plugin/world.yaml
+++ b/flatland_server/test/plugin_manager_tests/duplicate_plugin/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "2d"
     map: "../load_dummy_test/map.yaml"

--- a/flatland_server/test/plugin_manager_tests/duplicate_plugin/world_plugins.yaml
+++ b/flatland_server/test/plugin_manager_tests/duplicate_plugin/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/plugin_manager_tests/invalid_plugin_yaml/world.yaml
+++ b/flatland_server/test/plugin_manager_tests/invalid_plugin_yaml/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "2d"
     map: "../load_dummy_test/map.yaml"

--- a/flatland_server/test/plugin_manager_tests/invalid_plugin_yaml/world_plugins.yaml
+++ b/flatland_server/test/plugin_manager_tests/invalid_plugin_yaml/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/plugin_manager_tests/load_dummy_test/world.yaml
+++ b/flatland_server/test/plugin_manager_tests/load_dummy_test/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "2d"
     map: "map.yaml"

--- a/flatland_server/test/plugin_manager_tests/load_dummy_test/world_plugins.yaml
+++ b/flatland_server/test/plugin_manager_tests/load_dummy_test/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/plugin_manager_tests/nonexistent_plugin/world.yaml
+++ b/flatland_server/test/plugin_manager_tests/nonexistent_plugin/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "2d"
     map: "../load_dummy_test/map.yaml"

--- a/flatland_server/test/plugin_manager_tests/nonexistent_plugin/world_plugins.yaml
+++ b/flatland_server/test/plugin_manager_tests/nonexistent_plugin/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/plugin_manager_tests/plugin_throws_exception/world.yaml
+++ b/flatland_server/test/plugin_manager_tests/plugin_throws_exception/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "2d"
     map: "../load_dummy_test/map.yaml"

--- a/flatland_server/test/plugin_manager_tests/plugin_throws_exception/world_plugins.yaml
+++ b/flatland_server/test/plugin_manager_tests/plugin_throws_exception/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/service_manager_test.cpp
+++ b/flatland_server/test/service_manager_test.cpp
@@ -61,7 +61,7 @@ class ServiceManagerTest : public ::testing::Test {
  protected:
   SimulationManager* sim_man;
   boost::filesystem::path this_file_dir;
-  boost::filesystem::path world_yaml;
+  boost::filesystem::path world_path;
   boost::filesystem::path robot_yaml;
   Timekeeper timekeeper;
   ros::NodeHandle nh;
@@ -80,8 +80,10 @@ class ServiceManagerTest : public ::testing::Test {
   }
 
   void StartSimulationThread() {
-    sim_man =
-        new SimulationManager(world_yaml.string(), 1000, 1 / 1000.0, false, 0);
+    sim_man = new SimulationManager(world_path.string() + "world.yaml",
+                                    world_path.string(),
+                                    world_path.string() + "world_plugins.yaml",
+                                    1000, 1 / 1000.0 , false, 0);
     simulation_thread = std::thread(&ServiceManagerTest::SimulationThread,
                                     dynamic_cast<ServiceManagerTest*>(this));
   }
@@ -98,8 +100,7 @@ class ServiceManagerTest : public ::testing::Test {
  * Testing service for loading a model which should succeed
  */
 TEST_F(ServiceManagerTest, spawn_valid_model) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/simple_test_A/world.yaml");
+  world_path = this_file_dir / fs::path("load_world_tests/simple_test_A/");
 
   robot_yaml = this_file_dir /
                fs::path("load_world_tests/simple_test_A/person.model.yaml");
@@ -108,7 +109,7 @@ TEST_F(ServiceManagerTest, spawn_valid_model) {
 
   srv.request.name = "service_manager_test_robot";
   srv.request.ns = "robot123";
-  srv.request.yaml_path = robot_yaml.string();
+  srv.request.yaml_name = robot_yaml.string();
   srv.request.pose.x = 101.1;
   srv.request.pose.y = 102.1;
   srv.request.pose.theta = 0.23;
@@ -140,15 +141,14 @@ TEST_F(ServiceManagerTest, spawn_valid_model) {
  * Testing service for loading a model which should fail
  */
 TEST_F(ServiceManagerTest, spawn_invalid_model) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/simple_test_A/world.yaml");
+  world_path = this_file_dir / fs::path("load_world_tests/simple_test_A/");
 
   robot_yaml = this_file_dir / fs::path("random_path/turtlebot.model.yaml");
 
   flatland_msgs::SpawnModel srv;
 
   srv.request.name = "service_manager_test_robot";
-  srv.request.yaml_path = robot_yaml.string();
+  srv.request.yaml_name = robot_yaml.string();
   srv.request.pose.x = 1;
   srv.request.pose.y = 2;
   srv.request.pose.theta = 3;
@@ -176,8 +176,7 @@ TEST_F(ServiceManagerTest, spawn_invalid_model) {
  * Testing service for moving a valid model
  */
 TEST_F(ServiceManagerTest, move_model) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/simple_test_A/world.yaml");
+  world_path = this_file_dir / fs::path("load_world_tests/simple_test_A/");
 
   flatland_msgs::MoveModel srv;
   srv.request.name = "turtlebot1";
@@ -196,18 +195,17 @@ TEST_F(ServiceManagerTest, move_model) {
 
   World* w = sim_man->world_;
   EXPECT_NEAR(5.5, w->models_[0]->bodies_[0]->physics_body_->GetPosition().x,
-              1e-2);
+              1e-1);
   EXPECT_NEAR(9.9, w->models_[0]->bodies_[0]->physics_body_->GetPosition().y,
-              1e-2);
-  EXPECT_NEAR(0.77, w->models_[0]->bodies_[0]->physics_body_->GetAngle(), 1e-2);
+              1e-1);
+  EXPECT_NEAR(0.77, w->models_[0]->bodies_[0]->physics_body_->GetAngle(), 1e-1);
 }
 
 /**
  * Testing service for moving a nonexistent model
  */
 TEST_F(ServiceManagerTest, move_nonexistent_model) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/simple_test_A/world.yaml");
+  world_path = this_file_dir / fs::path("load_world_tests/simple_test_A/");
 
   flatland_msgs::MoveModel srv;
   srv.request.name = "not_a_robot";
@@ -233,8 +231,8 @@ TEST_F(ServiceManagerTest, move_nonexistent_model) {
  * Testing service for deleting a model
  */
 TEST_F(ServiceManagerTest, delete_model) {
-  world_yaml = this_file_dir /
-               fs::path("plugin_manager_tests/load_dummy_test/world.yaml");
+  world_path =
+      this_file_dir / fs::path("plugin_manager_tests/load_dummy_test/");
 
   flatland_msgs::DeleteModel srv;
   srv.request.name = "turtlebot1";
@@ -260,8 +258,8 @@ TEST_F(ServiceManagerTest, delete_model) {
  * Testing service for deleting a model that does not exist, should fail
  */
 TEST_F(ServiceManagerTest, delete_nonexistent_model) {
-  world_yaml = this_file_dir /
-               fs::path("plugin_manager_tests/load_dummy_test/world.yaml");
+  world_path =
+      this_file_dir / fs::path("plugin_manager_tests/load_dummy_test/");
 
   flatland_msgs::DeleteModel srv;
   srv.request.name = "random_model";

--- a/flatland_viz/CMakeLists.txt
+++ b/flatland_viz/CMakeLists.txt
@@ -70,6 +70,7 @@ link_directories(${catkin_LIBRARY_DIRS})
 
 ## This setting causes Qt's "MOC" generation to happen automatically.
 set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOMOC_COMPILER_PREDEFINES OFF)
 
 ## This plugin includes Qt widgets, so we must include Qt.
 ## We'll use the version that rviz used so they are compatible.

--- a/flatland_viz/src/spawn_model_tool.cpp
+++ b/flatland_viz/src/spawn_model_tool.cpp
@@ -183,7 +183,7 @@ void SpawnModelTool::SpawnModelInFlatland() {
   // fill in the service request
   srv.request.name = model_name.toStdString();
   srv.request.ns = model_name.toStdString();
-  srv.request.yaml_path = path_to_model_file_.toStdString();
+  srv.request.yaml_name = path_to_model_file_.toStdString();
   srv.request.pose.x = intersection[0];
   srv.request.pose.y = intersection[1];
   srv.request.pose.theta = initial_angle;


### PR DESCRIPTION
Rebased all Rapyuta Robotics changes on top of avidbots/flatland master (74 upstream commits: IMU plugin, laser simplify_map, diff-drive TF option, performance improvements, version 1.4.1).

RR changes preserved:
- MessageServer: in-process pub/sub messaging (message_server.h/cpp)
- Profiler: lightweight sim profiling (profiler.h + START/END_PROFILE in laser)
- World YAML split: world.yaml + world_plugins.yaml separation (137 test files)
- SimulationManager: LoadWorldEntities(), models_path_, world_plugins_path_, wait-for-map loop, ros::WallRate, ServiceManager as unique_ptr member
- DiffDrive: enable_ground_truth_pub_ independent of enable_odom_pub_
- Restartable simulation, wall timer, service manager improvements

Conflict resolutions:
- laser.h/cpp: kept upstream upside_down_ (was flipped_) + always_publish_; activated START/END_PROFILE macros from rr-devel
- diff_drive.h/cpp: kept upstream enable_odom_tf_pub_/twist_in_local_frame_; added rr-devel enable_ground_truth_pub_ as independent flag
- simulation_manager.h: merged both field sets (Timekeeper/iterations + RR fields)
- simulation_manager.cpp: took rr-devel (LoadWorldEntities restructuring)
- layer.cpp: took upstream cv::inRange fix (occupied_thresh direction)
- conestogo world.yaml: took upstream