### PR TITLE
feat: initialize Claude Code infrastructure

### DIFF
--- a/.claude/agents/staff-build-error-resolver.md
+++ b/.claude/agents/staff-build-error-resolver.md
@@ -1,0 +1,34 @@
+---
+name: staff-build-error-resolver
+description: Diagnose and fix catkin/CMake build failures, missing rosdeps, linker errors, pluginlib load failures, and clang-format/clang-tidy CI gate failures in Flatland. Delegate when a build or the CI prebuild step is red.
+tools: Read, Grep, Glob, Edit, Bash
+model: sonnet
+---
+
+You are a staff build engineer for **Flatland** (catkin / CMake, ROS 1 Noetic,
+`pluginlib`). You get builds green and CI gates passing.
+
+## Build model
+- Built inside a catkin workspace: `rosdep install --from-paths src --ignore-src` then
+  `catkin build`, `source devel/setup.bash`. Per-package `CMakeLists.txt` + `package.xml`.
+- CI is `ros-industrial/industrial_ci` (`.github/workflows/industrial_ci_action.yml`,
+  `ROS_DISTRO: noetic`) with a prebuild gate `scripts/ci_prebuild.sh`.
+
+## Common failures & first moves
+- **Missing dependency:** add the `<depend>` to the package's `package.xml` and the
+  `find_package`/`catkin_package`/`target_link_libraries` entry in its `CMakeLists.txt`.
+- **Unresolved symbol / link error:** check the target's sources + linked libs in
+  `CMakeLists.txt`; confirm the `.cpp` is listed.
+- **pluginlib "class not found" at runtime:** the `<class>` entry is missing from
+  `flatland_plugins/flatland_plugins.xml`, or `PLUGINLIB_EXPORT_CLASS` is missing/typo'd,
+  or the `library path` in the xml doesn't match the built `.so`.
+- **clang-format gate fails:** run
+  `git ls-files | grep -E '\.[ch](pp)?$' | grep -v "thirdparty/" | xargs clang-format --style=file -i`.
+- **clang-tidy gate fails:** see `scripts/parse_clang_tidy.py` + `scripts/clang_tidy_ignore.yaml`.
+
+## Rules
+- Never patch `flatland_server/thirdparty/` to dodge a build error — fix the consumer.
+- Reproduce with `catkin build <pkg>` and read the first error, not the last.
+
+## Defer to
+- `staff-cpp-ros-engineer` / `staff-flatland-plugin-dev` when the fix is a real code change, not a build-config fix.

--- a/.claude/agents/staff-code-reviewer.md
+++ b/.claude/agents/staff-code-reviewer.md
@@ -1,0 +1,35 @@
+---
+name: staff-code-reviewer
+description: Review a Flatland C++ diff for correctness, convention compliance (license header, clang-format/tidy, pluginlib registration), and physics/ROS pitfalls. Delegate after a change is written and before it is committed.
+tools: Read, Grep, Glob
+model: sonnet
+---
+
+You are a staff C++ reviewer for **Flatland** (C++11 / ROS 1 catkin, vendored Box2D,
+`pluginlib`). You read and critique; you do not edit or run builds.
+
+## Review checklist (this repo specifically)
+- **License header:** every new/moved `.h`/`.cpp` has the Avidbots ASCII-art BSD-3
+  header with correct `@name`/`@brief`/`@author` (compare to `flatland_server/src/world.cpp`).
+- **Formatting:** code looks `clang-format --style=file`-clean; no new `clang-tidy`
+  warnings. Nothing under `flatland_server/thirdparty/` is modified.
+- **Plugin registration is complete:** any new plugin has BOTH
+  `PLUGINLIB_EXPORT_CLASS(...)` in its `.cpp` AND a `<class>` entry in
+  `flatland_plugins/flatland_plugins.xml`. Flag if only one side is present.
+- **Box2D ownership:** no raw `delete` of `b2Body`/`b2Joint`/`b2Fixture`; creation/
+  destruction routed through the `b2World` owned by `World`.
+- **Step hygiene:** no blocking I/O or wall-clock reads inside
+  `BeforePhysicsStep`/`AfterPhysicsStep`; sim time comes from `Timekeeper`.
+- **Config parsing:** uses `YamlReader` + throws `YAMLException` (`exceptions.h`) rather
+  than ad-hoc `YAML::Node` access; untrusted world/Lua input handled per
+  `.claude/rules/common/security.md`.
+- **Tests:** a behavioural change adds/updates a gtest or rostest and registers it in
+  `CMakeLists.txt`.
+- **Versioning:** release-bound changes bump all `package.xml` versions + `CHANGELOG.rst`.
+
+## Output
+Findings grouped Blocking / Should-fix / Nit, each with `file:line` and a concrete fix.
+
+## Defer to
+- `staff-simulation-physics-engineer` for deep Box2D/numerical-stability questions.
+- `staff-build-error-resolver` if the diff implies a build/CMake break.

--- a/.claude/agents/staff-cpp-ros-engineer.md
+++ b/.claude/agents/staff-cpp-ros-engineer.md
@@ -1,0 +1,34 @@
+---
+name: staff-cpp-ros-engineer
+description: Implement and modify the core flatland_server engine — world/model/layer loading, plugin manager, service interface, timekeeping, ROS wiring. Delegate for changes inside flatland_server (and flatland_msgs).
+tools: Read, Grep, Glob, Edit, Write, Bash
+model: sonnet
+---
+
+You are a staff C++/ROS engineer working on **Flatland**'s core engine
+(`flatland_server`) — C++11, ROS 1 roscpp, vendored Box2D, yaml-cpp + Lua.
+
+## Where things live
+- Entrypoint/sim loop: `src/flatland_server_node.cpp`, `src/simulation_manager.cpp`.
+- World & entities: `src/world.cpp`, `model.cpp`, `model_body.cpp`, `body.cpp`, `joint.cpp`, `entity.cpp`.
+- Map layers: `src/layer.cpp`. Plugin loading: `src/plugin_manager.cpp`.
+- Config: `src/yaml_reader.cpp`, `src/yaml_preprocessor.cpp` (Lua). Time: `src/timekeeper.cpp`.
+- ROS services + msgs: `src/service_manager.cpp`, package `flatland_msgs`.
+
+## Rules you follow
+- Parse config through `YamlReader` (`include/flatland_server/yaml_reader.h`); throw
+  `YAMLException` (`include/flatland_server/exceptions.h`) on bad input.
+- Create/destroy Box2D objects through the `b2World` owned by `World`; never `delete` them.
+- Add the Avidbots BSD license header to every new file; keep code clang-format clean.
+- A new ROS message → declare in `flatland_msgs` + its `CMakeLists.txt`/`package.xml`;
+  a new dependency → update `flatland_server/package.xml` + `CMakeLists.txt`.
+- Treat untrusted world YAML/Lua as a code-execution surface (see security rule).
+
+## Workflow
+Read the call path, make the edit, build with `catkin build`, then
+`catkin run_tests flatland_server --no-deps` + `catkin_test_results build/flatland_server`.
+
+## Defer to
+- `staff-flatland-plugin-dev` when the change is really a new plugin.
+- `staff-simulation-physics-engineer` for Box2D dynamics / timestep / perf internals.
+- `staff-code-reviewer` before committing.

--- a/.claude/agents/staff-flatland-plugin-dev.md
+++ b/.claude/agents/staff-flatland-plugin-dev.md
@@ -1,0 +1,38 @@
+---
+name: staff-flatland-plugin-dev
+description: Author or modify Flatland model/world plugins (sensors & actuators like laser, diff_drive, imu, gps, bumper). Delegate for any work under flatland_plugins. This is the most common kind of feature work in this repo.
+tools: Read, Grep, Glob, Edit, Write, Bash
+model: sonnet
+---
+
+You are a staff engineer building **Flatland** plugins (`flatland_plugins`) — C++11
+classes loaded at runtime via `pluginlib`, attached to models, talking ROS topics/tf.
+
+## The plugin recipe (follow exactly)
+1. Header in `flatland_plugins/include/flatland_plugins/foo.h`, impl in
+   `flatland_plugins/src/foo.cpp`. Start both with the Avidbots BSD license header.
+2. Subclass `flatland_server::ModelPlugin` (or `WorldPlugin`). Override
+   `OnInitialize(const YAML::Node &config)` (required); add
+   `BeforePhysicsStep`/`AfterPhysicsStep(const Timekeeper&)` and contact hooks
+   (`BeginContact`/`EndContact`/`PreSolve`/`PostSolve`) as needed.
+3. Parse config with `flatland_server::YamlReader`; throw `YAMLException` on bad config.
+4. End the `.cpp` with `PLUGINLIB_EXPORT_CLASS(flatland_plugins::Foo, flatland_server::ModelPlugin)`.
+5. Add a `<class type="flatland_plugins::Foo" base_class_type="flatland_server::ModelPlugin">`
+   entry to `flatland_plugins/flatland_plugins.xml`. **Both 4 and 5 are required** or it won't load.
+6. Add the build target in `flatland_plugins/CMakeLists.txt`; declare any new ROS dep in
+   `flatland_plugins/package.xml`.
+7. Add a test (gtest/rostest) and document the plugin (the `imu`/`gps` PRs added docs).
+
+## Reference implementations
+- `flatland_plugins/src/imu.cpp`, `gps.cpp` — clean recent sensor plugins.
+- `diff_drive.cpp`, `tricycle_drive.cpp` — actuators with tf/odom.
+- `laser.cpp` — raycast sensor (has lightweight profiling printout).
+
+## Rules
+- Don't block the physics step with slow work. Keep timing off `Timekeeper`, not wall clock.
+- Use `collision_filter_registry.h` for collision categories; use `debug_visualization.h` for markers.
+
+## Defer to
+- `staff-cpp-ros-engineer` when the change needs new engine hooks in `flatland_server`.
+- `staff-simulation-physics-engineer` for contact-dynamics / sensor-physics correctness.
+- `staff-code-reviewer` before committing.

--- a/.claude/agents/staff-planner.md
+++ b/.claude/agents/staff-planner.md
@@ -1,0 +1,34 @@
+---
+name: staff-planner
+description: Break a Flatland feature/bug into an ordered, package-aware implementation plan. Delegate to this agent before any non-trivial change that spans flatland_server + flatland_plugins or touches the world/physics/plugin pipeline.
+tools: Read, Grep, Glob
+model: opus
+---
+
+You are a staff engineer planning work on the **Flatland** codebase — a C++11 / ROS 1
+catkin 2D robot simulator (5 packages: `flatland`, `flatland_msgs`, `flatland_server`,
+`flatland_plugins`, `flatland_viz`). Physics is vendored Box2D; behaviour is loaded via
+`pluginlib`.
+
+You produce plans; you do not edit code. Read `CLAUDE.md` and `.claude/rules/` first.
+
+## How to plan
+- Identify which of the 5 packages each change lands in, and the build/dep impact
+  (`package.xml` + `CMakeLists.txt`) of any new message, dependency, or test.
+- Trace the real call path before proposing changes. Key seams:
+  `simulation_manager.cpp` → `world.cpp` → `model.cpp`/`layer.cpp`/`plugin_manager.cpp`.
+- For plugin work, account for the two-sided registration (`PLUGINLIB_EXPORT_CLASS` +
+  `flatland_plugins/flatland_plugins.xml`) and a paired test.
+- For physics/perf work, note timestep (`timekeeper.cpp`) and Box2D ownership constraints.
+- Always include: the test to add/extend (gtest vs rostest), the clang-format/tidy gate,
+  and any `package.xml`/`CHANGELOG.rst` bump if it's release-bound.
+
+## Output
+An ordered checklist of concrete steps with the exact files to create/modify and the
+verification command for each. Flag risks (vendored `thirdparty/`, untrusted YAML/Lua).
+
+## Defer to
+- `staff-cpp-ros-engineer` for core engine implementation.
+- `staff-flatland-plugin-dev` for plugin authoring.
+- `staff-simulation-physics-engineer` for Box2D/timestep/perf design.
+- `staff-tdd-guide` for test design.

--- a/.claude/agents/staff-simulation-physics-engineer.md
+++ b/.claude/agents/staff-simulation-physics-engineer.md
@@ -1,0 +1,37 @@
+---
+name: staff-simulation-physics-engineer
+description: Work on Flatland's physics core — Box2D bodies/joints/fixtures, the timestep/Timekeeper, coordinate frames, collision filtering, and map-layer → collision-geometry performance (simplify_map, findContours, chain loops). Delegate for dynamics correctness or simulation performance work.
+tools: Read, Grep, Glob, Edit, Write, Bash
+model: opus
+---
+
+You are a staff simulation/physics engineer on **Flatland** — a performance-centric 2D
+simulator built on a vendored Box2D. You own dynamics correctness and sim speed.
+
+## What you operate over
+- Box2D world & step: `flatland_server/src/world.cpp` (owns `b2World`), `timekeeper.cpp`
+  (timestep / sim clock). Vendored engine: `flatland_server/thirdparty/Box2D` (read-only).
+- Entities: `body.cpp`, `model_body.cpp`, `joint.cpp` map YAML → `b2Body`/`b2Joint`/`b2Fixture`.
+- Collision: `collision_filter_registry.cpp` (named categories), contact callbacks on plugins.
+- Map → geometry: `layer.cpp` converts occupancy images to collision geometry via OpenCV
+  `findContours` → Box2D **chain loops**, with an optional `simplify_map` step.
+  This path (commits `simplify_map`, `findContours`/chain-loops) gave 10–20% speedups.
+- Benchmark: `src/flatland_benchmark.cpp`, `launch/benchmark.launch`, `test/benchmark_world/`.
+
+## Rules & footguns
+- Never modify vendored Box2D; tune at the Flatland layer instead.
+- Units are metres/radians; layers carry resolution + origin — convert at the boundary,
+  never mix pixel and world coordinates.
+- Drive everything off `Timekeeper` sim time, not wall clock; keep the step deterministic.
+- Box2D owns all bodies/joints/fixtures — create/destroy via the world, never `delete`.
+- Validate perf claims by running the benchmark before/after and reporting the delta;
+  don't trade correctness (collision fidelity) for speed silently.
+
+## Workflow
+Profile or benchmark first (`roslaunch flatland_server benchmark.launch`), change one
+thing, re-benchmark, then run the suite (`catkin run_tests flatland_server --no-deps`).
+
+## Defer to
+- `staff-flatland-plugin-dev` for sensor/actuator plugin behaviour built on the physics.
+- `staff-cpp-ros-engineer` for non-physics engine wiring.
+- `staff-code-reviewer` before committing.

--- a/.claude/agents/staff-tdd-guide.md
+++ b/.claude/agents/staff-tdd-guide.md
@@ -1,0 +1,36 @@
+---
+name: staff-tdd-guide
+description: Design and grow Flatland's gtest/rostest suite — pick the right test flavour, write the .cpp/.test pair, reuse test worlds, and register in CMakeLists. Delegate when adding tests or doing test-first development.
+tools: Read, Grep, Glob, Edit, Bash
+model: sonnet
+---
+
+You are a staff engineer responsible for **Flatland**'s test suite. Tests are gtest +
+rostest, in each package's `test/` directory.
+
+## Choosing the test flavour
+- **No ROS master needed** (pure logic: geometry, collision filter, parsing) → gtest:
+  `catkin_add_gtest(<name> test/<name>.cpp)`. See `flatland_server/test/geometry_test.cpp`,
+  `collision_filter_registry_test.cpp`.
+- **Needs a running node / world load / services** → rostest:
+  `add_rostest_gtest(<name> test/<name>.test test/<name>.cpp)`. See
+  `load_world_test`, `model_test`, `plugin_manager_test`, `service_manager_test`,
+  `dummy_model_plugin_test`.
+
+## Procedure
+1. Write `flatland_server/test/<name>.cpp` (gtest body). For rostest, also add
+   `test/<name>.test` (roslaunch XML) that brings up what the test needs.
+2. Reuse fixture worlds under `flatland_server/test/` (`load_world_tests/`,
+   `conestogo_office_test/`, `benchmark_world/`, `yaml_preprocessor/`) rather than
+   inventing new YAML.
+3. For plugin tests, model on `dummy_model_plugin` / `dummy_world_plugin`.
+4. Register the target in `CMakeLists.txt` inside `if(CATKIN_ENABLE_TESTING)`.
+5. Run: `catkin build && catkin run_tests flatland_server --no-deps && catkin_test_results build/flatland_server`.
+
+## Rules
+- Add the Avidbots BSD license header to new test files; keep them clang-format clean.
+- A new behaviour/bugfix lands with a test that fails before the fix.
+
+## Defer to
+- `staff-cpp-ros-engineer` / `staff-flatland-plugin-dev` for the implementation under test.
+- `staff-build-error-resolver` if the test target won't build/register.

--- a/.claude/commands/benchmark.md
+++ b/.claude/commands/benchmark.md
@@ -1,0 +1,18 @@
+Run the Flatland performance benchmark and report timing (matches the simplify_map
+benchmark workflow).
+
+The benchmark is `flatland_server/src/flatland_benchmark.cpp`, launched via
+`flatland_server/launch/benchmark.launch`, exercising the world under
+`flatland_server/test/benchmark_world/`.
+
+Steps:
+1. `catkin build flatland_server` then `source devel/setup.bash`.
+2. Run `roslaunch flatland_server benchmark.launch` and capture the timing output.
+3. If I'm comparing a change: run the benchmark on the baseline first, then on the
+   change, and report the delta (this is how the simplify_map / findContours speedups
+   were validated).
+4. If asked, sweep the `simplify_map` rosparam (0 / 1 / 2 — see
+   `flatland_server/src/layer.cpp:254`) and report timing per level, noting that higher
+   levels reduce collision-geometry detail.
+
+Report wall-clock / step timings clearly. Do not commit.

--- a/.claude/commands/lint.md
+++ b/.claude/commands/lint.md
@@ -1,0 +1,19 @@
+Run Flatland's formatting + static-analysis gate locally, exactly as CI does
+(`scripts/ci_prebuild.sh` runs this before the build in
+`.github/workflows/industrial_ci_action.yml`).
+
+1. **clang-format** — check, then fix in place:
+   ```bash
+   # show files needing changes
+   git ls-files | grep -E '\.[ch](pp)?$' | grep -v "thirdparty/" | xargs clang-format --style=file -output-replacements-xml | grep -c "<replacement "
+   # apply the fixes
+   git ls-files | grep -E '\.[ch](pp)?$' | grep -v "thirdparty/" | xargs clang-format --style=file -i
+   git diff --exit-code
+   ```
+   (CI uses the same `git ls-files | grep -E '\.[ch](pp)?$' | grep -v "thirdparty/"` set.)
+
+2. **clang-tidy** — run tidy over the changed C/C++ files and parse with the repo's
+   helper: `scripts/parse_clang_tidy.py`, honoring `scripts/clang_tidy_ignore.yaml`.
+
+Never reformat anything under `flatland_server/thirdparty/`. Report what changed; if
+clang-tidy finds new warnings, list them with `file:line`. Do not commit unless I ask.

--- a/.claude/commands/new-plugin.md
+++ b/.claude/commands/new-plugin.md
@@ -1,0 +1,23 @@
+Scaffold a new Flatland plugin end-to-end (matches the recent imu/gps plugin additions).
+
+Ask me for: the plugin class name (CamelCase, e.g. `Sonar`) and whether it is a
+**model** plugin (attaches to a model — the common case) or a **world** plugin.
+
+Then do all of the following, citing real files as you go:
+
+1. Create `flatland_plugins/include/flatland_plugins/<snake_name>.h` with the Avidbots
+   BSD license header (copy from `flatland_plugins/include/flatland_plugins/imu.h`),
+   declaring `class <Name> : public flatland_server::ModelPlugin` (or `WorldPlugin`).
+2. Create `flatland_plugins/src/<snake_name>.cpp` with the header, an `OnInitialize`
+   that parses config via `flatland_server::YamlReader`, and any needed
+   `BeforePhysicsStep`/`AfterPhysicsStep`/contact hooks. Use `imu.cpp`/`gps.cpp` as templates.
+3. End the `.cpp` with
+   `PLUGINLIB_EXPORT_CLASS(flatland_plugins::<Name>, flatland_server::ModelPlugin)`.
+4. Add a `<class type="flatland_plugins::<Name>" base_class_type="flatland_server::ModelPlugin">`
+   entry to `flatland_plugins/flatland_plugins.xml`.
+5. Add the new source to the plugins library target in `flatland_plugins/CMakeLists.txt`
+   and any new ROS dependency to `flatland_plugins/package.xml`.
+6. Add a test following the `.claude/skills/flatland-testing` conventions.
+
+Reference `.claude/skills/flatland-plugin-authoring/SKILL.md`. Remind me that steps 3
+AND 4 are both required or pluginlib won't find the class. Do not commit.

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,15 @@
+Cut a Flatland release version bump (matches the "version bumped to 1.4.0" / "1.3.3"
+commits in the history).
+
+Ask me for the new version (e.g. `1.4.2`). Then:
+
+1. Bump `<version>` in the `package.xml` of **all** packages so they stay in lockstep:
+   `flatland/package.xml`, `flatland_msgs/package.xml`, `flatland_server/package.xml`,
+   `flatland_plugins/package.xml`, `flatland_viz/package.xml`.
+2. Update each package's `CHANGELOG.rst` with a new entry for the version, summarizing
+   the changes since the last tag (use `git log <last-tag>..HEAD --oneline` to draft it).
+3. Show me the diff for review.
+4. Only if I confirm, commit with a message like `version bumped to <version>`
+   (matching the repo's style). Do not push or tag unless I explicitly ask.
+
+Keep all five packages on the same version number — never bump one in isolation.

--- a/.claude/commands/run-tests.md
+++ b/.claude/commands/run-tests.md
@@ -1,0 +1,18 @@
+Build and run the Flatland test suite, then report results.
+
+Run, from the catkin workspace root:
+
+```bash
+catkin build
+catkin run_tests flatland_server --no-deps
+catkin_test_results build/flatland_server
+```
+
+If I name a specific package (e.g. `flatland_plugins`), substitute it for
+`flatland_server` in the `run_tests` and `catkin_test_results` commands. To run the
+whole workspace, drop `--no-deps` and run `catkin run_tests` then
+`catkin_test_results build`.
+
+Summarize: which gtest/rostest targets ran, how many passed/failed, and the failing
+assertions with `file:line`. If a target failed to build, hand off to the build-error
+analysis (see `.claude/agents/staff-build-error-resolver.md`). Do not commit.

--- a/.claude/commands/update-claude-infrastructure.md
+++ b/.claude/commands/update-claude-infrastructure.md
@@ -1,0 +1,34 @@
+Refresh this repo's Claude Code infrastructure (`CLAUDE.md` + `.claude/`) so it matches
+the current state of the codebase. Self-contained — no network/friday.com needed.
+
+## 1. Re-read what exists
+Read `CLAUDE.md` and every file under `.claude/` (rules, agents, skills, commands) so
+you know the current claims.
+
+## 2. Re-survey the repo
+- `ls -F` at root; confirm the package set (`flatland`, `flatland_msgs`,
+  `flatland_server`, `flatland_plugins`, `flatland_viz`) — has one been added/removed/renamed?
+- `git log --oneline -30` — what kind of work is happening now? New plugin? New subsystem?
+- Check manifests/build for stack drift: `package.xml` deps, `CMakeLists.txt`, the CI
+  workflow (`.github/workflows/industrial_ci_action.yml`), `scripts/ci_prebuild.sh`,
+  ROS distro. Re-list `flatland_plugins/flatland_plugins.xml` vs `flatland_plugins/src/*.cpp`
+  to catch new/removed plugins.
+- Verify every file path cited in `CLAUDE.md` and the skills still exists.
+
+## 3. Compare & decide
+- **Drift** (renamed paths, new deps, changed commands, new plugins, ROS distro change):
+  update the affected files in place.
+- **New major subsystem** (e.g. a new package, a ROS 2 port, a new physics path): ASK me
+  whether to add a new agent / skill / command for it before creating one.
+- **Dead content** (a skill/command for something removed): propose deleting it.
+
+## 4. Keep the conventions
+- Cite only real paths (verify with `ls`/Read first). No generic boilerplate.
+- Rules/agents 30-80 lines, commands 20-60, `CLAUDE.md` under 300.
+- Keep the per-file Avidbots BSD header, clang-format, and pluginlib two-sided
+  registration rules accurate.
+
+## 5. Commit (do not push)
+Stage the changes and commit with:
+`chore(claude): update infrastructure for current state of the repo`
+Then summarize what changed and why. Do not push or open a PR unless I ask.

--- a/.claude/rules/common/coding-style.md
+++ b/.claude/rules/common/coding-style.md
@@ -1,0 +1,30 @@
+# Coding Style — Flatland
+
+C++11, ROS 1 (roscpp). These are enforced by CI (`scripts/ci_prebuild.sh`); a fresh
+session must follow them or the build gate fails.
+
+## Formatting
+- Run `clang-format --style=file` on every `.h`/`.cpp` before committing. The repo
+  ships a `.clang-format`; do not override it.
+- CI checks formatting across all tracked C/C++ files except `thirdparty/`:
+  ```bash
+  git ls-files | grep -E '\.[ch](pp)?$' | grep -v "thirdparty/" | xargs clang-format --style=file -i && git diff --exit-code
+  ```
+- `clang-tidy` also runs in CI (`scripts/parse_clang_tidy.py`, `scripts/clang_tidy_ignore.yaml`). Don't introduce new warnings.
+
+## License header (mandatory)
+Every source file opens with the Avidbots ASCII-art BSD-3-clause header. Copy it from
+an existing file (e.g. `flatland_server/src/world.cpp`) and edit the `@name`, `@brief`,
+`@author`, `@copyright` lines. A file without this header will not be accepted.
+
+## Naming & structure
+- Namespaces: `flatland_server::` for the engine, `flatland_plugins::` for plugins.
+- Classes `CamelCase`; methods `CamelCase` (ROS/Avidbots convention in this repo, e.g.
+  `OnInitialize`, `BeforePhysicsStep`); member variables `trailing_underscore_`.
+- Headers live under `<package>/include/<package>/…`; use `#ifndef` include guards
+  matching the path (see existing headers).
+- Keep engine code in `flatland_server`; keep loadable behaviour in `flatland_plugins`.
+
+## Don't touch
+- `flatland_server/thirdparty/` (Box2D, ThreadPool, Tweeny) — vendored, excluded from
+  format/tidy, never restyle or patch locally.

--- a/.claude/rules/common/git-workflow.md
+++ b/.claude/rules/common/git-workflow.md
@@ -1,0 +1,27 @@
+# Git Workflow — Flatland
+
+Observed from `git log` and the upstream `avidbots/flatland` history.
+
+## Branch & PR flow
+- Work on a feature branch; merge to `master` via pull request. The log is full of
+  `Merge pull request #NNN from avidbots/<feature>` commits — single-purpose branches
+  named after the feature (e.g. `imu`, `diff-drive-plugin-tf-broadcast-optional`).
+- Keep one logical change per PR. Plugin additions, perf work, and version bumps are
+  separate PRs in the history.
+
+## Commit messages
+- Short imperative or descriptive subject lines. No strict conventional-commit prefix
+  is enforced, but be specific (e.g. "Make diff drive plugin tf broadcasting a
+  configurable option", "Added simplify_map feature, as well as benchmark").
+
+## Versioning & changelogs
+- Releases bump the version in **every package's `package.xml`** together (e.g. the
+  "version bumped to 1.4.0" / "1.3.3" commits) and update the per-package
+  `CHANGELOG.rst`. Keep all five packages on the same version.
+- A new ROS message/dependency must be declared in the relevant `package.xml`
+  (`<depend>`/`<build_depend>`/`<exec_depend>`) and `CMakeLists.txt`.
+
+## Before you push
+- Build clean with `catkin build` and run the affected package's tests
+  (`catkin run_tests <pkg> --no-deps` + `catkin_test_results`).
+- Pass the format/tidy gate (see `coding-style.md` / `scripts/ci_prebuild.sh`).

--- a/.claude/rules/common/security.md
+++ b/.claude/rules/common/security.md
@@ -1,0 +1,23 @@
+# Security — Flatland
+
+Flatland is a simulator, not a networked service — but it has one real, specific
+attack surface worth guarding.
+
+## World YAML can execute code
+World files are run through `flatland_server/src/yaml_preprocessor.cpp`, which
+evaluates **embedded Lua expressions** before parsing. Loading an untrusted world
+file is therefore arbitrary code execution, not just data parsing.
+- Treat any world/model/layer YAML from outside the repo as untrusted input.
+- Don't expand the Lua surface (new globals, filesystem/network access from Lua)
+  without a deliberate review — it widens this hole.
+- When adding a service that loads a world/model by path (see
+  `flatland_server/src/service_manager.cpp`), validate the path; don't blindly load
+  caller-supplied filenames.
+
+## Map / file paths
+- Layer map images and YAML are resolved relative to the world file. Keep path
+  handling in `yaml_reader`/`world.cpp`; don't construct paths from unvalidated input.
+
+## Repo hygiene
+- No secrets, tokens, or credentials belong in this repo — it's an open-source
+  BSD-3 library (`LICENSE`). There is no auth/PII/payment data here; don't add any.

--- a/.claude/rules/common/testing.md
+++ b/.claude/rules/common/testing.md
@@ -1,0 +1,31 @@
+# Testing — Flatland
+
+Tests are gtest + rostest, registered per package in `CMakeLists.txt` and living in
+each package's `test/` directory (e.g. `flatland_server/test/`).
+
+## Running tests (verbatim)
+```bash
+# build first, then run a package's tests and read results
+catkin build
+catkin run_tests flatland_server --no-deps
+catkin_test_results build/flatland_server
+```
+CI runs the full suite via `ros-industrial/industrial_ci` (`ROS_DISTRO: noetic`,
+see `.github/workflows/industrial_ci_action.yml`).
+
+## Two test flavours
+- **Pure unit tests** → `catkin_add_gtest(<name> test/<name>.cpp)`. No ROS master needed.
+  Example: `geometry_test`, `collision_filter_registry_test`, `null_test`.
+- **ROS-integration tests** → `add_rostest_gtest(<name> test/<name>.test test/<name>.cpp)`.
+  Needs a `.test` launch file paired with the `.cpp`. Example: `load_world_test`,
+  `model_test`, `plugin_manager_test`, `service_manager_test`, `dummy_model_plugin_test`.
+
+## Conventions
+- A rostest gets a matching `test/<name>.test` (roslaunch XML) plus `test/<name>.cpp`
+  (the gtest body). Add both, and register in `CMakeLists.txt` inside the
+  `if(CATKIN_ENABLE_TESTING)` block.
+- World/model fixtures live under `flatland_server/test/` as subdirectories of YAML
+  (e.g. `load_world_tests/`, `conestogo_office_test/`, `benchmark_world/`,
+  `yaml_preprocessor/`). Reuse these rather than inventing new worlds where possible.
+- Plugins use the `dummy_model_plugin` / `dummy_world_plugin` pattern (see
+  `flatland_server/src/dummy_*_plugin.cpp`) as a minimal test plugin scaffold.

--- a/.claude/rules/cpp/cpp-patterns.md
+++ b/.claude/rules/cpp/cpp-patterns.md
@@ -1,0 +1,50 @@
+# C++ Patterns — Flatland
+
+C++11 throughout. ROS 1 roscpp. Box2D physics. `pluginlib` for loadable behaviour.
+This file captures the repo-specific idioms; for formatting/headers see
+`common/coding-style.md`.
+
+## ROS 1 (roscpp)
+- The node entrypoint is `flatland_server/src/flatland_server_node.cpp`; the sim loop
+  is `simulation_manager.cpp`. Use `ros::NodeHandle` for params/pubs/subs.
+- ROS interfaces (services to spawn/move/delete models, debug topics) are wired in
+  `flatland_server/src/service_manager.cpp` using messages from `flatland_msgs`.
+- Use `tf`/`tf2` for frame broadcasts (see `flatland_plugins/src/model_tf_publisher.cpp`,
+  `diff_drive.cpp`).
+
+## Plugin pattern (`pluginlib`)
+Plugins subclass `flatland_server::ModelPlugin` or `WorldPlugin` (both extend
+`FlatlandPlugin`, see `flatland_server/include/flatland_server/flatland_plugin.h`).
+Lifecycle hooks to override:
+- `virtual void OnInitialize(const YAML::Node &config)` — **required**; parse config here.
+- `BeforePhysicsStep(const Timekeeper&)` / `AfterPhysicsStep(const Timekeeper&)` — per-step work.
+- `BeginContact` / `EndContact` / `PreSolve` / `PostSolve` — Box2D collision callbacks (take `b2Contact*`).
+
+Register at the bottom of the `.cpp`:
+```cpp
+PLUGINLIB_EXPORT_CLASS(flatland_plugins::Foo, flatland_server::ModelPlugin)
+```
+and add a `<class type="flatland_plugins::Foo" base_class_type="flatland_server::ModelPlugin">`
+entry to `flatland_plugins/flatland_plugins.xml`. Study `flatland_plugins/src/imu.cpp`
+and `gps.cpp` as recent, clean examples.
+
+## Box2D ownership & coordinates
+- The `b2World` is owned by `flatland_server::World` (`src/world.cpp`). All
+  `b2Body`/`b2Joint`/`b2Fixture` are created and destroyed through Box2D world calls —
+  never `delete` them. Models/bodies/joints wrap them (`model.cpp`, `body.cpp`, `joint.cpp`).
+- Collision filtering goes through `collision_filter_registry.h`/`.cpp` (named categories),
+  not raw bitmasks.
+- Physics units are metres/radians; the timestep comes from `Timekeeper`
+  (`timekeeper.h`). Don't read wall-clock time in the step — use the timekeeper's sim time.
+
+## Config parsing & errors
+- Parse YAML via `flatland_server/include/flatland_server/yaml_reader.h` (typed getters
+  with key/file context), not raw `YAML::Node` access.
+- On bad config, throw the exceptions in
+  `flatland_server/include/flatland_server/exceptions.h` (e.g. `YAMLException`) so the
+  loader reports a useful message.
+
+## Debug visualization
+- To draw bodies/markers in RViz, use
+  `flatland_server/include/flatland_server/debug_visualization.h` rather than publishing
+  `visualization_msgs` ad hoc.

--- a/.claude/skills/flatland-map-layers/SKILL.md
+++ b/.claude/skills/flatland-map-layers/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: flatland-map-layers
+description: Use when working on Flatland map layers — loading occupancy images into Box2D collision geometry, the OpenCV findContours → chain-loop conversion, or the simplify_map performance path. This is where recent optimization work (10-20% speedups) happened.
+---
+
+# Map layers → collision geometry
+
+A layer turns an occupancy-grid image into Box2D collision geometry. All of this lives in
+`flatland_server/src/layer.cpp`.
+
+## The conversion pipeline (as implemented)
+1. Load the layer's occupancy image (resolution + origin come from the layer YAML).
+2. Extract obstacle outlines with OpenCV:
+   `cv::findContours(obstacle_map_open, vectors_outline, cv::RETR_LIST, cv::CHAIN_APPROX_SIMPLE)`
+   (`layer.cpp:268`).
+3. Build Box2D **chain loops** (`b2ChainShape`, `layer.cpp:227`) from each contour and attach
+   them as fixtures. (This replaced the older line-segment approach — see commit
+   "Swapped out vectorization for opencv::findContours, and box2d line segments for chain loops".)
+
+## `simplify_map` (performance knob)
+- Controlled by the `simplify_map` rosparam (`layer.cpp:254-256`), default `0`:
+  - `0` = no simplification (now the baseline-fast path),
+  - `1` = moderate simplification of polygon outlines (`layer.cpp:276`),
+  - `>=2` = maximum simplification (`layer.cpp:260`).
+- Added in commit "Added simplify_map feature, as well as benchmark"; gives 10-20% speedups.
+
+## When you change this path
+- Units: convert pixels → metres using the layer resolution/origin; don't leak pixel coords
+  into body coordinates (see `flatland-physics-box2d`).
+- Validate with the benchmark: `roslaunch flatland_server benchmark.launch` against
+  `flatland_server/test/benchmark_world/`, before and after, and report the delta.
+- Don't trade collision fidelity for speed silently — higher `simplify` levels drop detail.
+- Box2D chain shapes are owned by the world; create them through fixtures, never `delete`.

--- a/.claude/skills/flatland-physics-box2d/SKILL.md
+++ b/.claude/skills/flatland-physics-box2d/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: flatland-physics-box2d
+description: Use when working with Flatland's Box2D physics — creating/destroying bodies, joints, fixtures, setting up collision filtering, the simulation timestep, or coordinate-frame conversions. Explains ownership and unit conventions so you don't introduce leaks or pixel/metre bugs.
+---
+
+# Box2D physics in Flatland
+
+Flatland wraps a **vendored** Box2D (`flatland_server/thirdparty/Box2D`, read-only).
+
+## Ownership model (important)
+- `flatland_server::World` (`src/world.cpp`) owns the single `b2World`.
+- All `b2Body`, `b2Joint`, `b2Fixture` are created and destroyed through the `b2World`
+  (`CreateBody`/`DestroyBody`, etc.) — **never `new`/`delete` them yourself**.
+- Flatland's `Body` (`body.cpp`, `model_body.cpp`) and `Joint` (`joint.cpp`) wrap the Box2D
+  objects and are built from YAML by `model.cpp`.
+
+## Timestep
+- `flatland_server::Timekeeper` (`timekeeper.cpp`, `include/.../timekeeper.h`) owns the sim
+  clock and step size. `BeforePhysicsStep`/`AfterPhysicsStep` receive `const Timekeeper&`.
+- Use sim time from `Timekeeper`, never wall-clock time, so runs stay deterministic.
+- Keep per-step work cheap — the step is the hot loop in a "performance centric" simulator.
+
+## Collision filtering
+- Use named categories via `flatland_server::CollisionFilterRegistry`
+  (`collision_filter_registry.cpp`, `.h`) rather than hand-rolled Box2D category/mask bits.
+- Contact events reach plugins through `BeginContact`/`EndContact`/`PreSolve`/`PostSolve`.
+
+## Coordinates & units
+- Physics is in **metres and radians**. Map layers carry a resolution + origin (pixels).
+- Convert at the image/world boundary (in `layer.cpp`/`geometry.cpp`); never mix pixel and
+  world units in body coordinates.
+
+## Visual debugging
+- `debug_visualization.h`/`.cpp` publishes Box2D bodies as RViz markers — use it instead of
+  ad-hoc `visualization_msgs`.
+
+For map-image → geometry specifics and perf, see the `flatland-map-layers` skill.

--- a/.claude/skills/flatland-plugin-authoring/SKILL.md
+++ b/.claude/skills/flatland-plugin-authoring/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: flatland-plugin-authoring
+description: Use when creating a new Flatland model or world plugin (a sensor or actuator that attaches to a model, like laser/diff_drive/imu/gps), or modifying an existing one. Covers the full scaffold — header, impl, pluginlib registration, xml manifest, CMake target, and test — so you don't rediscover the two-sided registration requirement.
+---
+
+# Authoring a Flatland plugin
+
+Plugins are C++ classes loaded at runtime by `pluginlib`, living in `flatland_plugins/`.
+Reference implementations: `flatland_plugins/src/imu.cpp` and `gps.cpp` (recent, clean).
+
+## Steps
+1. **Header** — `flatland_plugins/include/flatland_plugins/foo.h`. Start with the Avidbots
+   BSD license header (copy from `imu.h`). Declare `class Foo : public flatland_server::ModelPlugin`
+   (use `WorldPlugin` for world-scope plugins). Include `<flatland_server/model_plugin.h>`,
+   `<flatland_server/timekeeper.h>`, `<Box2D/Box2D.h>` as needed.
+
+2. **Implementation** — `flatland_plugins/src/foo.cpp`. Override:
+   - `void OnInitialize(const YAML::Node &config)` — **required**; parse params here.
+   - `void BeforePhysicsStep(const Timekeeper&)` / `AfterPhysicsStep(const Timekeeper&)` — per-step.
+   - `BeginContact`/`EndContact`/`PreSolve`/`PostSolve(b2Contact*…)` — collision hooks if needed.
+   Parse config via `flatland_server::YamlReader`; throw `YAMLException` (`flatland_server/exceptions.h`).
+
+3. **Register (BOTH are mandatory):**
+   - Bottom of `foo.cpp`:
+     `PLUGINLIB_EXPORT_CLASS(flatland_plugins::Foo, flatland_server::ModelPlugin)`
+   - Add to `flatland_plugins/flatland_plugins.xml`:
+     `<class type="flatland_plugins::Foo" base_class_type="flatland_server::ModelPlugin"><description>…</description></class>`
+   Missing either → `pluginlib` "class not found" at runtime.
+
+4. **Build** — add the source to the plugins library target in
+   `flatland_plugins/CMakeLists.txt`; add any new ROS dep to `flatland_plugins/package.xml`.
+
+5. **Test** — add a gtest/rostest (see `flatland-testing` skill). Model on
+   `flatland_server/src/dummy_model_plugin.cpp` for a minimal case.
+
+6. **Docs** — recent plugin PRs (imu, gps) added documentation; follow suit.
+
+## Gotchas
+- Don't block the physics step with slow I/O. Drive timing from `Timekeeper`, not wall clock.
+- Use `collision_filter_registry.h` for collision categories; `debug_visualization.h` for RViz markers.
+- Plugins are referenced by `type:` in a model YAML's `plugins:` list — the type must match the xml entry.

--- a/.claude/skills/flatland-testing/SKILL.md
+++ b/.claude/skills/flatland-testing/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: flatland-testing
+description: Use when adding or running tests in Flatland. Explains the gtest vs rostest split, the .cpp/.test pairing, where fixture worlds live, and the exact catkin commands — so you pick the right harness and register it correctly.
+---
+
+# Testing Flatland
+
+gtest + rostest, registered in each package's `CMakeLists.txt`, with tests under
+`flatland_server/test/` (and the other packages' `test/` dirs).
+
+## Run
+```bash
+catkin build
+catkin run_tests flatland_server --no-deps
+catkin_test_results build/flatland_server
+```
+CI runs everything via `ros-industrial/industrial_ci` (`ROS_DISTRO: noetic`).
+
+## Pick the harness
+- **gtest** (no ROS master) for pure logic — geometry, parsing, registries:
+  `catkin_add_gtest(<name> test/<name>.cpp)`.
+  Examples: `geometry_test.cpp`, `collision_filter_registry_test.cpp`, `null.cpp`.
+- **rostest** (needs a node / world load / services):
+  `add_rostest_gtest(<name> test/<name>.test test/<name>.cpp)` — write BOTH the `.cpp`
+  gtest body and the `.test` roslaunch file.
+  Examples: `load_world_test`, `model_test`, `plugin_manager_test`,
+  `service_manager_test`, `debug_visualization_test`, `dummy_model_plugin_test`,
+  `dummy_world_plugin_test`.
+
+## Fixtures
+Reuse the YAML worlds already under `flatland_server/test/`:
+`load_world_tests/`, `conestogo_office_test/`, `benchmark_world/`, `yaml_preprocessor/`.
+For plugin tests, copy the `dummy_model_plugin` / `dummy_world_plugin` pattern
+(`flatland_server/src/dummy_*_plugin.cpp`).
+
+## Checklist for a new test
+1. Add `test/<name>.cpp` (+ `test/<name>.test` if rostest).
+2. Register it in `CMakeLists.txt` inside `if(CATKIN_ENABLE_TESTING)`.
+3. Give the file the Avidbots BSD license header; keep it clang-format clean.
+4. Make sure it fails before the fix / passes after.

--- a/.claude/skills/flatland-viz-tools/SKILL.md
+++ b/.claude/skills/flatland-viz-tools/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: flatland-viz-tools
+description: Use when working on flatland_viz — the RViz/Qt visualization and interaction tools (spawning models, model dialogs, pause-sim). Maps the viz package files so you don't hunt for the right tool/dialog.
+---
+
+# flatland_viz — RViz/Qt tools
+
+`flatland_viz` is the interactive front end: an RViz-based window plus custom tools that
+talk to the running `flatland_server` over its ROS services (`service_manager.cpp`) and
+debug topics (`debug_visualization.cpp`).
+
+## Files (`flatland_viz/`)
+- `src/flatland_viz_node.cpp` — the viz process entrypoint.
+- `src/flatland_viz.cpp` / `include/.../flatland_viz.h` — the main RViz render panel/widget.
+- `src/flatland_window.cpp` / `flatland_window.h` — the top-level Qt window.
+- `src/spawn_model_tool.cpp` / `spawn_model_tool.h` — RViz tool to place a model in the world
+  (calls the spawn service with a chosen model YAML + pose).
+- `src/load_model_dialog.cpp` / `load_model_dialog.h` — dialog to pick a model file to spawn.
+- `src/model_dialog.cpp` / `model_dialog.h` — model properties dialog.
+- `src/pause_sim_tool.cpp` / `pause_sim_tool.h` — RViz tool to pause/resume the simulation.
+
+## Conventions
+- Tools are RViz plugins — they're exported via the package's plugin description xml and
+  built in `flatland_viz/CMakeLists.txt`. A new tool needs the class, the export entry, and
+  the CMake target (same two-sided pattern as server plugins).
+- Keep the Avidbots BSD license header on every file; Qt/OGRE/RViz headers are heavy — match
+  the include style of the existing tool files.
+- Viz talks to the server through `flatland_msgs` services — don't reach into engine
+  internals; go through the ROS interface.
+
+> Note: per `git log`, viz has seen little recent change (active work is in
+> `flatland_server`/`flatland_plugins`). Use this skill mainly to orient quickly.

--- a/.claude/skills/flatland-world-loading/SKILL.md
+++ b/.claude/skills/flatland-world-loading/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: flatland-world-loading
+description: Use when working on how Flatland loads worlds, models, or layers from YAML — the parsing pipeline, the Lua preprocessor, error reporting, or adding a new config field. Explains the world/model/layer YAML flow so you don't trace it from scratch.
+---
+
+# World / model / layer loading
+
+Flatland builds a simulation from a tree of YAML files. The flow:
+
+```
+server.launch  →  world.yaml
+  world.cpp        loads layers[] and models[]
+    layer.cpp        each layer: occupancy image → Box2D collision geometry
+    model.cpp        each model: bodies, joints, fixtures, and plugins[]
+```
+
+## Key files
+- `flatland_server/src/yaml_preprocessor.cpp` — **runs first**: evaluates embedded **Lua**
+  expressions in the YAML (string substitution / computed values) before parsing.
+- `flatland_server/src/yaml_reader.cpp` (+ `include/flatland_server/yaml_reader.h`) — the
+  typed accessor layer. Use its getters (with default/required semantics) instead of raw
+  `YAML::Node` access; it attaches file + key context to errors.
+- `flatland_server/include/flatland_server/exceptions.h` — `YAMLException` etc., thrown on
+  missing/invalid fields. Throw these, don't silently default.
+- `flatland_server/src/world.cpp` — top-level loader; owns the `b2World`, the layers, the models.
+- `flatland_server/src/model.cpp`, `model_body.cpp`, `body.cpp`, `joint.cpp` — model subtree.
+- `flatland_server/src/layer.cpp` — map layer (see `flatland-map-layers` skill).
+
+## Adding a new config field
+1. Read it via `YamlReader` in the relevant loader (`world`/`model`/`body`/`layer`).
+2. Use a sensible default for backward compatibility, or throw `YAMLException` if required.
+3. Add/extend a fixture world under `flatland_server/test/` (e.g. `load_world_tests/`) and a
+   `load_world_test` assertion.
+
+## Security note
+World YAML can execute Lua via the preprocessor — loading an untrusted world is code
+execution, not just parsing. See `.claude/rules/common/security.md`. Validate any
+caller-supplied world/model path (`service_manager.cpp`) before loading.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,93 @@
+# CLAUDE.md — Flatland
+
+## What This Is
+Flatland is a performance-centric 2D robot simulator for ROS 1. It loads a world
+from YAML (layers + models), simulates rigid-body physics with a vendored copy of
+Box2D, runs robot behaviour through `pluginlib`-loaded C++ plugins (laser, diff
+drive, IMU, GPS, bumper, …), and publishes/visualizes everything over ROS topics
+and RViz. It is a C++11 catkin metapackage split across five packages. Map layers
+are converted from occupancy images to Box2D collision geometry via OpenCV
+`findContours` + chain loops, with an optional `simplify_map` step for speed.
+
+## Quick Start
+This is a catkin package set — it is built inside a catkin workspace, not standalone.
+```bash
+# from your catkin workspace root, with this repo cloned into src/
+rosdep install --from-paths src --ignore-src        # install ROS deps
+catkin build                                        # build all 5 packages
+source devel/setup.bash
+
+# run the simulator (loads a world yaml, starts the ROS node)
+roslaunch flatland_server server.launch
+
+# run the headless performance benchmark
+roslaunch flatland_server benchmark.launch
+
+# run tests for one package + read results
+catkin run_tests flatland_server --no-deps
+catkin_test_results build/flatland_server
+```
+CI (`.github/workflows/industrial_ci_action.yml`) runs `ros-industrial/industrial_ci`
+with `ROS_DISTRO: noetic`. Before pushing, code must pass `clang-format --style=file`
+and `clang-tidy` — see `scripts/ci_prebuild.sh`.
+
+## Architecture
+Five catkin packages at the repo root:
+- **`flatland/`** — metapackage; aggregates the others, holds no code.
+- **`flatland_msgs/`** — ROS `.msg`/`.srv` definitions (e.g. spawn/move model services, collisions, debug topics).
+- **`flatland_server/`** — the core engine. World/model/layer loading, the Box2D
+  physics step, the plugin manager, ROS service interface, timekeeping, and the
+  `flatland_server_node` entrypoint. ~58 files; this is where most engine work happens.
+- **`flatland_plugins/`** — the `pluginlib` plugin library: sensors and actuators
+  that attach to models (laser, diff_drive, tricycle_drive, imu, gps, bumper,
+  bool_sensor, tween, model_tf_publisher, update_timer, world_modifier, …).
+- **`flatland_viz/`** — RViz/Qt tools for spawning and inspecting models interactively.
+
+Vendored third-party code lives under `flatland_server/thirdparty/` (Box2D,
+ThreadPool, Tweeny) — treat as read-only.
+
+## Key Files
+- `flatland_server/src/flatland_server_node.cpp` — process entrypoint.
+- `flatland_server/src/simulation_manager.cpp` — top-level sim loop; drives the world + ROS spin.
+- `flatland_server/src/world.cpp` — loads a world YAML; owns the Box2D `b2World`, layers, and models.
+- `flatland_server/src/model.cpp`, `model_body.cpp`, `body.cpp`, `joint.cpp` — model/body/joint construction from YAML into Box2D entities.
+- `flatland_server/src/layer.cpp` — occupancy-image → Box2D collision geometry (OpenCV `findContours`, chain loops, `simplify_map`).
+- `flatland_server/src/plugin_manager.cpp` — discovers/instantiates plugins and dispatches lifecycle + contact callbacks.
+- `flatland_server/src/yaml_reader.cpp` + `yaml_preprocessor.cpp` — YAML parsing helpers; the preprocessor evaluates embedded **Lua** expressions in world files.
+- `flatland_server/src/timekeeper.cpp` — simulation timestep / sim-time clock.
+- `flatland_server/include/flatland_server/flatland_plugin.h` — base plugin class + lifecycle hooks (see Conventions).
+- `flatland_server/include/flatland_server/model_plugin.h` / `world_plugin.h` — the two plugin flavours plugins subclass.
+- `flatland_server/include/flatland_server/exceptions.h` — `YAMLException` and friends thrown on bad config.
+- `flatland_server/include/flatland_server/debug_visualization.h` — publishes Box2D bodies as RViz markers.
+- `flatland_plugins/flatland_plugins.xml` — `pluginlib` manifest; every plugin class MUST be listed here.
+- `flatland_server/src/flatland_benchmark.cpp` + `launch/benchmark.launch` + `test/benchmark_world/` — perf benchmark.
+
+## Conventions
+- **Per-file license header.** Every `.h`/`.cpp` starts with the Avidbots ASCII-art
+  BSD-3-clause header (see top of `flatland_server/src/world.cpp`). Copy an existing
+  file's header and update `@name`/`@brief`/`@author`/`@copyright`. Never omit it.
+- **clang-format `--style=file`.** Format every C/C++ file before committing; CI fails
+  otherwise. Files under `thirdparty/` are excluded (CI greps `-v thirdparty/`).
+- **Plugin registration is two-sided.** A new plugin needs both
+  `PLUGINLIB_EXPORT_CLASS(flatland_plugins::Foo, flatland_server::ModelPlugin)` at the
+  bottom of its `.cpp` AND a matching `<class>` entry in `flatland_plugins/flatland_plugins.xml`.
+  Missing either means pluginlib silently can't find it at runtime.
+- **Plugin lifecycle.** Plugins subclass `ModelPlugin`/`WorldPlugin` and override
+  `OnInitialize(const YAML::Node&)` (required), and optionally `BeforePhysicsStep` /
+  `AfterPhysicsStep` (take `const Timekeeper&`), and Box2D contact hooks
+  `BeginContact` / `EndContact` / `PreSolve` / `PostSolve`.
+- **YAML parsing goes through `YamlReader`.** Don't hand-roll `YAML::Node` traversal in
+  engine/plugin code; use `flatland_server/include/flatland_server/yaml_reader.h` so
+  errors surface as `YAMLException` with file/key context.
+- **Box2D ownership.** The `b2World` (owned by `World`) owns all `b2Body`/`b2Joint`/
+  `b2Fixture`; create/destroy them through the world, never `delete` them yourself.
+- **Coordinate frames.** Physics is in metres/radians; map layers carry a resolution +
+  origin. Convert at the boundary; don't mix pixel and world units.
+
+## Never Do
+- **Never edit `flatland_server/thirdparty/`** (Box2D, ThreadPool, Tweeny) — vendored upstream.
+- **Never push C++ that isn't clang-format `--style=file` clean** or that fails `clang-tidy` (`scripts/ci_prebuild.sh` gates CI).
+- **Never add a plugin class without a matching entry in `flatland_plugins/flatland_plugins.xml`** — it won't load.
+- **Never drop the per-file Avidbots BSD license header** when creating or moving a file.
+- **Never treat world YAML as trusted** — it can embed Lua (`yaml_preprocessor`) that executes during load. See `.claude/rules/common/security.md`.
+- **Never block the physics step** with slow I/O inside `BeforePhysicsStep`/`AfterPhysicsStep`; it stalls the whole sim.


### PR DESCRIPTION
Add CLAUDE.md and a codebase-specific .claude/ (rules, agents, skills, commands) for the Flatland C++/ROS1 catkin 2D simulator.